### PR TITLE
Update resource limit error messages

### DIFF
--- a/apps/api/src/common/constants/error-messages.ts
+++ b/apps/api/src/common/constants/error-messages.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+export const UPGRADE_TIER_MESSAGE = 'To increase concurrency limits, upgrade your organization\'s Tier by visiting <https://app.daytona.io/dashboard/limits>.'
+
+export const ARCHIVE_SANDBOXES_MESSAGE = 'Consider archiving your unused Sandboxes to free up available storage.'

--- a/apps/api/src/common/constants/error-messages.ts
+++ b/apps/api/src/common/constants/error-messages.ts
@@ -6,3 +6,5 @@
 export const UPGRADE_TIER_MESSAGE = 'To increase concurrency limits, upgrade your organization\'s Tier by visiting <https://app.daytona.io/dashboard/limits>.'
 
 export const ARCHIVE_SANDBOXES_MESSAGE = 'Consider archiving your unused Sandboxes to free up available storage.'
+
+export const PER_SANDBOX_LIMIT_MESSAGE = 'Need higher resource limits per-sandbox? Contact us at <mailto:support@daytona.io|support@daytona.io> and let us know about your use case.'

--- a/apps/api/src/common/constants/error-messages.ts
+++ b/apps/api/src/common/constants/error-messages.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-export const UPGRADE_TIER_MESSAGE = 'To increase concurrency limits, upgrade your organization\'s Tier by visiting <https://app.daytona.io/dashboard/limits>.'
+export const UPGRADE_TIER_MESSAGE = 'To increase concurrency limits, upgrade your organization\'s Tier by visiting https://app.daytona.io/dashboard/limits.'
 
 export const ARCHIVE_SANDBOXES_MESSAGE = 'Consider archiving your unused Sandboxes to free up available storage.'
 
-export const PER_SANDBOX_LIMIT_MESSAGE = 'Need higher resource limits per-sandbox? Contact us at <mailto:support@daytona.io|support@daytona.io> and let us know about your use case.'
+export const PER_SANDBOX_LIMIT_MESSAGE = 'Need higher resource limits per-sandbox? Contact us at support@daytona.io and let us know about your use case.'

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -33,6 +33,7 @@ import { TrackJobExecution } from '../../common/decorators/track-job-execution.d
 import { setTimeout as sleep } from 'timers/promises'
 import { TypedConfigService } from '../../config/typed-config.service'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
+import { UPGRADE_TIER_MESSAGE, ARCHIVE_SANDBOXES_MESSAGE } from '../../common/constants/error-messages'
 
 @Injectable()
 export class SnapshotManager implements TrackableJobExecutions, OnApplicationShutdown {
@@ -676,11 +677,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       await this.updateSnapshotState(
         snapshot.id,
         SnapshotState.ERROR,
-        `Snapshot size (${snapshotInfo.sizeGB.toFixed(2)}GB) exceeds maximum allowed size of ${MAX_SIZE_GB}GB.
-
-Consider archiving your unused Sandboxes to free up available storage.
-
-To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`,
+        `Snapshot size (${snapshotInfo.sizeGB.toFixed(2)}GB) exceeds maximum allowed size of ${MAX_SIZE_GB}GB.\n\n${ARCHIVE_SANDBOXES_MESSAGE}\n\n${UPGRADE_TIER_MESSAGE}`,
       )
       return
     }

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -676,7 +676,11 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       await this.updateSnapshotState(
         snapshot.id,
         SnapshotState.ERROR,
-        `Snapshot size (${snapshotInfo.sizeGB.toFixed(2)}GB) exceeds maximum allowed size of ${MAX_SIZE_GB}GB`,
+        `Snapshot size (${snapshotInfo.sizeGB.toFixed(2)}GB) exceeds maximum allowed size of ${MAX_SIZE_GB}GB.
+
+Consider archiving your unused Sandboxes to free up available storage.
+
+To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`,
       )
       return
     }

--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -677,7 +677,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       await this.updateSnapshotState(
         snapshot.id,
         SnapshotState.ERROR,
-        `Snapshot size (${snapshotInfo.sizeGB.toFixed(2)}GB) exceeds maximum allowed size of ${MAX_SIZE_GB}GB.\n\n${ARCHIVE_SANDBOXES_MESSAGE}\n\n${UPGRADE_TIER_MESSAGE}`,
+        `Snapshot size (${snapshotInfo.sizeGB.toFixed(2)}GB) exceeds maximum allowed size of ${MAX_SIZE_GB}GB.\n${ARCHIVE_SANDBOXES_MESSAGE}\n${UPGRADE_TIER_MESSAGE}`,
       )
       return
     }

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -59,6 +59,7 @@ import {
 } from '../dto/list-sandboxes-query.dto'
 import { createRangeFilter } from '../../common/utils/range-filter'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
+import { UPGRADE_TIER_MESSAGE, ARCHIVE_SANDBOXES_MESSAGE } from '../../common/constants/error-messages'
 
 const DEFAULT_CPU = 1
 const DEFAULT_MEMORY = 1
@@ -105,25 +106,17 @@ export class SandboxService {
     // validate per-sandbox quotas
     if (cpu > organization.maxCpuPerSandbox) {
       throw new ForbiddenException(
-        `CPU request ${cpu} exceeds maximum allowed per sandbox (${organization.maxCpuPerSandbox}).
-
-To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`,
+        `CPU request ${cpu} exceeds maximum allowed per sandbox (${organization.maxCpuPerSandbox}).\n\n${UPGRADE_TIER_MESSAGE}`,
       )
     }
     if (memory > organization.maxMemoryPerSandbox) {
       throw new ForbiddenException(
-        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${organization.maxMemoryPerSandbox}GB).
-
-To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`,
+        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${organization.maxMemoryPerSandbox}GB).\n\n${UPGRADE_TIER_MESSAGE}`,
       )
     }
     if (disk > organization.maxDiskPerSandbox) {
       throw new ForbiddenException(
-        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${organization.maxDiskPerSandbox}GB).
-
-Consider archiving your unused Sandboxes to free up available storage.
-
-To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`,
+        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${organization.maxDiskPerSandbox}GB).\n\n${ARCHIVE_SANDBOXES_MESSAGE}\n\n${UPGRADE_TIER_MESSAGE}`,
       )
     }
 
@@ -144,25 +137,17 @@ To increase concurrency limits, upgrade your organization's Tier by visiting <ht
 
     try {
       if (usageOverview.currentCpuUsage + usageOverview.pendingCpuUsage > organization.totalCpuQuota) {
-        throw new ForbiddenException(`Total CPU limit exceeded. Maximum allowed: ${organization.totalCpuQuota}.
-
-To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`)
+        throw new ForbiddenException(`Total CPU limit exceeded. Maximum allowed: ${organization.totalCpuQuota}.\n\n${UPGRADE_TIER_MESSAGE}`)
       }
 
       if (usageOverview.currentMemoryUsage + usageOverview.pendingMemoryUsage > organization.totalMemoryQuota) {
         throw new ForbiddenException(
-          `Total memory limit exceeded. Maximum allowed: ${organization.totalMemoryQuota}GiB.
-
-To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`,
+          `Total memory limit exceeded. Maximum allowed: ${organization.totalMemoryQuota}GiB.\n\n${UPGRADE_TIER_MESSAGE}`,
         )
       }
 
       if (usageOverview.currentDiskUsage + usageOverview.pendingDiskUsage > organization.totalDiskQuota) {
-        throw new ForbiddenException(`Total disk limit exceeded. Maximum allowed: ${organization.totalDiskQuota}GiB.
-
-Consider archiving your unused Sandboxes to free up available storage.
-
-To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`)
+        throw new ForbiddenException(`Total disk limit exceeded. Maximum allowed: ${organization.totalDiskQuota}GiB.\n\n${ARCHIVE_SANDBOXES_MESSAGE}\n\n${UPGRADE_TIER_MESSAGE}`)
       }
     } catch (error) {
       await this.rollbackPendingUsage(

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -105,17 +105,25 @@ export class SandboxService {
     // validate per-sandbox quotas
     if (cpu > organization.maxCpuPerSandbox) {
       throw new ForbiddenException(
-        `CPU request ${cpu} exceeds maximum allowed per sandbox (${organization.maxCpuPerSandbox})`,
+        `CPU request ${cpu} exceeds maximum allowed per sandbox (${organization.maxCpuPerSandbox}).
+
+To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`,
       )
     }
     if (memory > organization.maxMemoryPerSandbox) {
       throw new ForbiddenException(
-        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${organization.maxMemoryPerSandbox}GB)`,
+        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${organization.maxMemoryPerSandbox}GB).
+
+To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`,
       )
     }
     if (disk > organization.maxDiskPerSandbox) {
       throw new ForbiddenException(
-        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${organization.maxDiskPerSandbox}GB)`,
+        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${organization.maxDiskPerSandbox}GB).
+
+Consider archiving your unused Sandboxes to free up available storage.
+
+To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`,
       )
     }
 
@@ -136,17 +144,25 @@ export class SandboxService {
 
     try {
       if (usageOverview.currentCpuUsage + usageOverview.pendingCpuUsage > organization.totalCpuQuota) {
-        throw new ForbiddenException(`Total CPU quota exceeded. Maximum allowed: ${organization.totalCpuQuota}`)
+        throw new ForbiddenException(`Total CPU limit exceeded. Maximum allowed: ${organization.totalCpuQuota}.
+
+To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`)
       }
 
       if (usageOverview.currentMemoryUsage + usageOverview.pendingMemoryUsage > organization.totalMemoryQuota) {
         throw new ForbiddenException(
-          `Total memory quota exceeded. Maximum allowed: ${organization.totalMemoryQuota}GiB`,
+          `Total memory limit exceeded. Maximum allowed: ${organization.totalMemoryQuota}GiB.
+
+To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`,
         )
       }
 
       if (usageOverview.currentDiskUsage + usageOverview.pendingDiskUsage > organization.totalDiskQuota) {
-        throw new ForbiddenException(`Total disk quota exceeded. Maximum allowed: ${organization.totalDiskQuota}GiB`)
+        throw new ForbiddenException(`Total disk limit exceeded. Maximum allowed: ${organization.totalDiskQuota}GiB.
+
+Consider archiving your unused Sandboxes to free up available storage.
+
+To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`)
       }
     } catch (error) {
       await this.rollbackPendingUsage(

--- a/apps/api/src/sandbox/services/sandbox.service.ts
+++ b/apps/api/src/sandbox/services/sandbox.service.ts
@@ -59,7 +59,7 @@ import {
 } from '../dto/list-sandboxes-query.dto'
 import { createRangeFilter } from '../../common/utils/range-filter'
 import { LogExecution } from '../../common/decorators/log-execution.decorator'
-import { UPGRADE_TIER_MESSAGE, ARCHIVE_SANDBOXES_MESSAGE } from '../../common/constants/error-messages'
+import { UPGRADE_TIER_MESSAGE, ARCHIVE_SANDBOXES_MESSAGE, PER_SANDBOX_LIMIT_MESSAGE } from '../../common/constants/error-messages'
 
 const DEFAULT_CPU = 1
 const DEFAULT_MEMORY = 1
@@ -106,17 +106,17 @@ export class SandboxService {
     // validate per-sandbox quotas
     if (cpu > organization.maxCpuPerSandbox) {
       throw new ForbiddenException(
-        `CPU request ${cpu} exceeds maximum allowed per sandbox (${organization.maxCpuPerSandbox}).\n\n${UPGRADE_TIER_MESSAGE}`,
+        `CPU request ${cpu} exceeds maximum allowed per sandbox (${organization.maxCpuPerSandbox}).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
     if (memory > organization.maxMemoryPerSandbox) {
       throw new ForbiddenException(
-        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${organization.maxMemoryPerSandbox}GB).\n\n${UPGRADE_TIER_MESSAGE}`,
+        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${organization.maxMemoryPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
     if (disk > organization.maxDiskPerSandbox) {
       throw new ForbiddenException(
-        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${organization.maxDiskPerSandbox}GB).\n\n${ARCHIVE_SANDBOXES_MESSAGE}\n\n${UPGRADE_TIER_MESSAGE}`,
+        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${organization.maxDiskPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
 
@@ -137,17 +137,17 @@ export class SandboxService {
 
     try {
       if (usageOverview.currentCpuUsage + usageOverview.pendingCpuUsage > organization.totalCpuQuota) {
-        throw new ForbiddenException(`Total CPU limit exceeded. Maximum allowed: ${organization.totalCpuQuota}.\n\n${UPGRADE_TIER_MESSAGE}`)
+        throw new ForbiddenException(`Total CPU limit exceeded. Maximum allowed: ${organization.totalCpuQuota}.\n${UPGRADE_TIER_MESSAGE}`)
       }
 
       if (usageOverview.currentMemoryUsage + usageOverview.pendingMemoryUsage > organization.totalMemoryQuota) {
         throw new ForbiddenException(
-          `Total memory limit exceeded. Maximum allowed: ${organization.totalMemoryQuota}GiB.\n\n${UPGRADE_TIER_MESSAGE}`,
+          `Total memory limit exceeded. Maximum allowed: ${organization.totalMemoryQuota}GiB.\n${UPGRADE_TIER_MESSAGE}`,
         )
       }
 
       if (usageOverview.currentDiskUsage + usageOverview.pendingDiskUsage > organization.totalDiskQuota) {
-        throw new ForbiddenException(`Total disk limit exceeded. Maximum allowed: ${organization.totalDiskQuota}GiB.\n\n${ARCHIVE_SANDBOXES_MESSAGE}\n\n${UPGRADE_TIER_MESSAGE}`)
+        throw new ForbiddenException(`Total disk limit exceeded. Maximum allowed: ${organization.totalDiskQuota}GiB.\n${ARCHIVE_SANDBOXES_MESSAGE}\n${UPGRADE_TIER_MESSAGE}`)
       }
     } catch (error) {
       await this.rollbackPendingUsage(

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -280,17 +280,25 @@ export class SnapshotService {
     // validate per-sandbox quotas
     if (cpu && cpu > organization.maxCpuPerSandbox) {
       throw new ForbiddenException(
-        `CPU request ${cpu} exceeds maximum allowed per sandbox (${organization.maxCpuPerSandbox})`,
+        `CPU request ${cpu} exceeds maximum allowed per sandbox (${organization.maxCpuPerSandbox}).
+
+To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`,
       )
     }
     if (memory && memory > organization.maxMemoryPerSandbox) {
       throw new ForbiddenException(
-        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${organization.maxMemoryPerSandbox}GB)`,
+        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${organization.maxMemoryPerSandbox}GB).
+
+To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`,
       )
     }
     if (disk && disk > organization.maxDiskPerSandbox) {
       throw new ForbiddenException(
-        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${organization.maxDiskPerSandbox}GB)`,
+        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${organization.maxDiskPerSandbox}GB).
+
+Consider archiving your unused Sandboxes to free up available storage.
+
+To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`,
       )
     }
 
@@ -301,7 +309,11 @@ export class SnapshotService {
 
     try {
       if (usageOverview.currentSnapshotUsage + usageOverview.pendingSnapshotUsage > organization.snapshotQuota) {
-        throw new ForbiddenException(`Snapshot quota exceeded. Maximum allowed: ${organization.snapshotQuota}`)
+        throw new ForbiddenException(`Snapshot limit exceeded. Maximum allowed: ${organization.snapshotQuota}.
+
+Consider archiving your unused Sandboxes to free up available storage.
+
+To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`)
       }
     } catch (error) {
       await this.rollbackPendingUsage(organization.id, addedSnapshotCount)

--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -33,7 +33,7 @@ import { PaginatedList } from '../../common/interfaces/paginated-list.interface'
 import { OrganizationUsageService } from '../../organization/services/organization-usage.service'
 import { RedisLockProvider } from '../common/redis-lock.provider'
 import { SnapshotSortDirection, SnapshotSortField } from '../dto/list-snapshots-query.dto'
-import { UPGRADE_TIER_MESSAGE, ARCHIVE_SANDBOXES_MESSAGE } from '../../common/constants/error-messages'
+import { PER_SANDBOX_LIMIT_MESSAGE } from '../../common/constants/error-messages'
 
 const IMAGE_NAME_REGEX = /^[a-zA-Z0-9_.\-:]+(\/[a-zA-Z0-9_.\-:]+)*$/
 @Injectable()
@@ -281,17 +281,17 @@ export class SnapshotService {
     // validate per-sandbox quotas
     if (cpu && cpu > organization.maxCpuPerSandbox) {
       throw new ForbiddenException(
-        `CPU request ${cpu} exceeds maximum allowed per sandbox (${organization.maxCpuPerSandbox}).\n\n${UPGRADE_TIER_MESSAGE}`,
+        `CPU request ${cpu} exceeds maximum allowed per sandbox (${organization.maxCpuPerSandbox}).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
     if (memory && memory > organization.maxMemoryPerSandbox) {
       throw new ForbiddenException(
-        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${organization.maxMemoryPerSandbox}GB).\n\n${UPGRADE_TIER_MESSAGE}`,
+        `Memory request ${memory}GB exceeds maximum allowed per sandbox (${organization.maxMemoryPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
     if (disk && disk > organization.maxDiskPerSandbox) {
       throw new ForbiddenException(
-        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${organization.maxDiskPerSandbox}GB).\n\n${ARCHIVE_SANDBOXES_MESSAGE}\n\n${UPGRADE_TIER_MESSAGE}`,
+        `Disk request ${disk}GB exceeds maximum allowed per sandbox (${organization.maxDiskPerSandbox}GB).\n${PER_SANDBOX_LIMIT_MESSAGE}`,
       )
     }
 
@@ -302,7 +302,7 @@ export class SnapshotService {
 
     try {
       if (usageOverview.currentSnapshotUsage + usageOverview.pendingSnapshotUsage > organization.snapshotQuota) {
-        throw new ForbiddenException(`Snapshot limit exceeded. Maximum allowed: ${organization.snapshotQuota}.\n\n${UPGRADE_TIER_MESSAGE}`)
+        throw new ForbiddenException(`Snapshot quota exceeded. Maximum allowed: ${organization.snapshotQuota}`)
       }
     } catch (error) {
       await this.rollbackPendingUsage(organization.id, addedSnapshotCount)

--- a/apps/api/src/sandbox/services/volume.service.ts
+++ b/apps/api/src/sandbox/services/volume.service.ts
@@ -42,7 +42,11 @@ export class VolumeService {
 
     try {
       if (usageOverview.currentVolumeUsage + usageOverview.pendingVolumeUsage > organization.volumeQuota) {
-        throw new ForbiddenException(`Volume quota exceeded. Maximum allowed: ${organization.volumeQuota}`)
+        throw new ForbiddenException(`Volume limit exceeded. Maximum allowed: ${organization.volumeQuota}.
+
+Consider archiving your unused Sandboxes to free up available storage.
+
+To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`)
       }
     } catch (error) {
       await this.rollbackPendingUsage(organization.id, addedVolumeCount)

--- a/apps/api/src/sandbox/services/volume.service.ts
+++ b/apps/api/src/sandbox/services/volume.service.ts
@@ -17,7 +17,6 @@ import { SandboxEvents } from '../constants/sandbox-events.constants'
 import { SandboxCreatedEvent } from '../events/sandbox-create.event'
 import { OrganizationService } from '../../organization/services/organization.service'
 import { OrganizationUsageService } from '../../organization/services/organization-usage.service'
-import { UPGRADE_TIER_MESSAGE, ARCHIVE_SANDBOXES_MESSAGE } from '../../common/constants/error-messages'
 
 @Injectable()
 export class VolumeService {
@@ -43,7 +42,7 @@ export class VolumeService {
 
     try {
       if (usageOverview.currentVolumeUsage + usageOverview.pendingVolumeUsage > organization.volumeQuota) {
-        throw new ForbiddenException(`Volume limit exceeded. Maximum allowed: ${organization.volumeQuota}.\n\n${ARCHIVE_SANDBOXES_MESSAGE}\n\n${UPGRADE_TIER_MESSAGE}`)
+        throw new ForbiddenException(`Volume quota exceeded. Maximum allowed: ${organization.volumeQuota}`)
       }
     } catch (error) {
       await this.rollbackPendingUsage(organization.id, addedVolumeCount)

--- a/apps/api/src/sandbox/services/volume.service.ts
+++ b/apps/api/src/sandbox/services/volume.service.ts
@@ -17,6 +17,7 @@ import { SandboxEvents } from '../constants/sandbox-events.constants'
 import { SandboxCreatedEvent } from '../events/sandbox-create.event'
 import { OrganizationService } from '../../organization/services/organization.service'
 import { OrganizationUsageService } from '../../organization/services/organization-usage.service'
+import { UPGRADE_TIER_MESSAGE, ARCHIVE_SANDBOXES_MESSAGE } from '../../common/constants/error-messages'
 
 @Injectable()
 export class VolumeService {
@@ -42,11 +43,7 @@ export class VolumeService {
 
     try {
       if (usageOverview.currentVolumeUsage + usageOverview.pendingVolumeUsage > organization.volumeQuota) {
-        throw new ForbiddenException(`Volume limit exceeded. Maximum allowed: ${organization.volumeQuota}.
-
-Consider archiving your unused Sandboxes to free up available storage.
-
-To increase concurrency limits, upgrade your organization's Tier by visiting <https://app.daytona.io/dashboard/limits>.`)
+        throw new ForbiddenException(`Volume limit exceeded. Maximum allowed: ${organization.volumeQuota}.\n\n${ARCHIVE_SANDBOXES_MESSAGE}\n\n${UPGRADE_TIER_MESSAGE}`)
       }
     } catch (error) {
       await this.rollbackPendingUsage(organization.id, addedVolumeCount)


### PR DESCRIPTION
# Enhance Resource Limit Exceeded Error Messages

## Description

This PR improves the clarity and actionability of user-facing error messages when resource limits (CPU, memory, disk, snapshots, volumes) are exceeded. The goal is to provide more helpful guidance to users.

Specifically, the changes include:
-   Replacing the term "quota" with "limit" for consistency.
-   Ensuring all error messages are properly punctuated with a full stop.
-   Adding a standard message directing users to upgrade their organization's Tier to increase concurrency limits.
-   For storage-related limits (disk, snapshot, volume), an additional suggestion to archive unused Sandboxes is now included to help users free up available storage.

- [ ] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

## Notes

---
[Slack Thread](https://asdf-gbj9121.slack.com/archives/D09KZH258LD/p1760298104896969?thread_ts=1760298104.896969&cid=D09KZH258LD)

<a href="https://cursor.com/background-agent?bcId=bc-627f6203-6be5-469f-b2fd-37e43c0db8fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-627f6203-6be5-469f-b2fd-37e43c0db8fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

