### PR TITLE
Add api key id to audit logs

### DIFF
--- a/apps/api/src/audit/adapters/audit-opensearch.adapter.ts
+++ b/apps/api/src/audit/adapters/audit-opensearch.adapter.ts
@@ -182,6 +182,7 @@ export class AuditOpenSearchStorageAdapter implements AuditLogStorageAdapter, On
     auditLog.actorId = source.actorId
     auditLog.actorEmail = source.actorEmail
     auditLog.organizationId = source.organizationId
+    auditLog.apiKeyId = source.apiKeyId
     auditLog.action = source.action
     auditLog.targetType = source.targetType
     auditLog.targetId = source.targetId

--- a/apps/api/src/audit/dto/audit-log.dto.ts
+++ b/apps/api/src/audit/dto/audit-log.dto.ts
@@ -20,6 +20,9 @@ export class AuditLogDto {
   @ApiPropertyOptional()
   organizationId?: string
 
+  @ApiPropertyOptional()
+  apiKeyId?: string
+
   @ApiProperty()
   action: string
 
@@ -59,6 +62,7 @@ export class AuditLogDto {
       actorId: auditLog.actorId,
       actorEmail: auditLog.actorEmail,
       organizationId: auditLog.organizationId,
+      apiKeyId: auditLog.apiKeyId,
       action: auditLog.action,
       targetType: auditLog.targetType,
       targetId: auditLog.targetId,

--- a/apps/api/src/audit/dto/create-audit-log-internal.dto.ts
+++ b/apps/api/src/audit/dto/create-audit-log-internal.dto.ts
@@ -11,6 +11,7 @@ export class CreateAuditLogInternalDto {
   actorId: string
   actorEmail: string
   organizationId?: string
+  apiKeyId?: string
   action: AuditAction
   targetType?: AuditTarget
   targetId?: string

--- a/apps/api/src/audit/entities/audit-log.entity.ts
+++ b/apps/api/src/audit/entities/audit-log.entity.ts
@@ -25,6 +25,9 @@ export class AuditLog {
   @Column({ nullable: true })
   organizationId?: string
 
+  @Column({ nullable: true })
+  apiKeyId?: string
+
   @Column()
   action: string
 

--- a/apps/api/src/audit/interceptors/audit.interceptor.ts
+++ b/apps/api/src/audit/interceptors/audit.interceptor.ts
@@ -75,10 +75,15 @@ export class AuditInterceptor implements NestInterceptor {
     observer: Subscriber<any>,
   ): Promise<void> {
     try {
+      const apiKeyId = request.user.apiKey
+        ? `${request.user.apiKey.organizationId}:${request.user.apiKey.userId}:${request.user.apiKey.name}`
+        : undefined
+
       const auditLog = await this.auditService.createLog({
         actorId: request.user.userId,
         actorEmail: request.user.email,
         organizationId: request.user.organizationId,
+        apiKeyId,
         action: auditContext.action,
         targetType: auditContext.targetType,
         targetId: this.resolveTargetId(auditContext, request),

--- a/apps/api/src/audit/services/audit.service.ts
+++ b/apps/api/src/audit/services/audit.service.ts
@@ -63,6 +63,7 @@ export class AuditService implements OnApplicationBootstrap {
     auditLog.actorId = createDto.actorId
     auditLog.actorEmail = createDto.actorEmail
     auditLog.organizationId = createDto.organizationId
+    auditLog.apiKeyId = createDto.apiKeyId
     auditLog.action = createDto.action
     auditLog.targetType = createDto.targetType
     auditLog.targetId = createDto.targetId

--- a/apps/api/src/migrations/1762471957455-migration.ts
+++ b/apps/api/src/migrations/1762471957455-migration.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2025 Daytona Platforms Inc.
+ * SPDX-License-Identifier: AGPL-3.0
+ */
+
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class Migration1762471957455 implements MigrationInterface {
+  name = 'Migration1762471957455'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "audit_log" ADD "apiKeyId" character varying`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "audit_log" DROP COLUMN "apiKeyId"`)
+  }
+}

--- a/libs/api-client-go/model_audit_log.go
+++ b/libs/api-client-go/model_audit_log.go
@@ -26,6 +26,7 @@ type AuditLog struct {
 	ActorId              string                 `json:"actorId"`
 	ActorEmail           string                 `json:"actorEmail"`
 	OrganizationId       *string                `json:"organizationId,omitempty"`
+	ApiKeyId             *string                `json:"apiKeyId,omitempty"`
 	Action               string                 `json:"action"`
 	TargetType           *string                `json:"targetType,omitempty"`
 	TargetId             *string                `json:"targetId,omitempty"`
@@ -165,6 +166,38 @@ func (o *AuditLog) HasOrganizationId() bool {
 // SetOrganizationId gets a reference to the given string and assigns it to the OrganizationId field.
 func (o *AuditLog) SetOrganizationId(v string) {
 	o.OrganizationId = &v
+}
+
+// GetApiKeyId returns the ApiKeyId field value if set, zero value otherwise.
+func (o *AuditLog) GetApiKeyId() string {
+	if o == nil || IsNil(o.ApiKeyId) {
+		var ret string
+		return ret
+	}
+	return *o.ApiKeyId
+}
+
+// GetApiKeyIdOk returns a tuple with the ApiKeyId field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *AuditLog) GetApiKeyIdOk() (*string, bool) {
+	if o == nil || IsNil(o.ApiKeyId) {
+		return nil, false
+	}
+	return o.ApiKeyId, true
+}
+
+// HasApiKeyId returns a boolean if a field has been set.
+func (o *AuditLog) HasApiKeyId() bool {
+	if o != nil && !IsNil(o.ApiKeyId) {
+		return true
+	}
+
+	return false
+}
+
+// SetApiKeyId gets a reference to the given string and assigns it to the ApiKeyId field.
+func (o *AuditLog) SetApiKeyId(v string) {
+	o.ApiKeyId = &v
 }
 
 // GetAction returns the Action field value
@@ -487,6 +520,9 @@ func (o AuditLog) ToMap() (map[string]interface{}, error) {
 	if !IsNil(o.OrganizationId) {
 		toSerialize["organizationId"] = o.OrganizationId
 	}
+	if !IsNil(o.ApiKeyId) {
+		toSerialize["apiKeyId"] = o.ApiKeyId
+	}
 	toSerialize["action"] = o.Action
 	if !IsNil(o.TargetType) {
 		toSerialize["targetType"] = o.TargetType
@@ -564,6 +600,7 @@ func (o *AuditLog) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "actorId")
 		delete(additionalProperties, "actorEmail")
 		delete(additionalProperties, "organizationId")
+		delete(additionalProperties, "apiKeyId")
 		delete(additionalProperties, "action")
 		delete(additionalProperties, "targetType")
 		delete(additionalProperties, "targetId")

--- a/libs/api-client-python-async/daytona_api_client_async/models/audit_log.py
+++ b/libs/api-client-python-async/daytona_api_client_async/models/audit_log.py
@@ -32,6 +32,7 @@ class AuditLog(BaseModel):
     actor_id: StrictStr = Field(alias="actorId")
     actor_email: StrictStr = Field(alias="actorEmail")
     organization_id: Optional[StrictStr] = Field(default=None, alias="organizationId")
+    api_key_id: Optional[StrictStr] = Field(default=None, alias="apiKeyId")
     action: StrictStr
     target_type: Optional[StrictStr] = Field(default=None, alias="targetType")
     target_id: Optional[StrictStr] = Field(default=None, alias="targetId")
@@ -43,7 +44,7 @@ class AuditLog(BaseModel):
     metadata: Optional[Dict[str, Any]] = None
     created_at: datetime = Field(alias="createdAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "actorId", "actorEmail", "organizationId", "action", "targetType", "targetId", "statusCode", "errorMessage", "ipAddress", "userAgent", "source", "metadata", "createdAt"]
+    __properties: ClassVar[List[str]] = ["id", "actorId", "actorEmail", "organizationId", "apiKeyId", "action", "targetType", "targetId", "statusCode", "errorMessage", "ipAddress", "userAgent", "source", "metadata", "createdAt"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -107,6 +108,7 @@ class AuditLog(BaseModel):
             "actorId": obj.get("actorId"),
             "actorEmail": obj.get("actorEmail"),
             "organizationId": obj.get("organizationId"),
+            "apiKeyId": obj.get("apiKeyId"),
             "action": obj.get("action"),
             "targetType": obj.get("targetType"),
             "targetId": obj.get("targetId"),

--- a/libs/api-client-python/daytona_api_client/models/audit_log.py
+++ b/libs/api-client-python/daytona_api_client/models/audit_log.py
@@ -32,6 +32,7 @@ class AuditLog(BaseModel):
     actor_id: StrictStr = Field(alias="actorId")
     actor_email: StrictStr = Field(alias="actorEmail")
     organization_id: Optional[StrictStr] = Field(default=None, alias="organizationId")
+    api_key_id: Optional[StrictStr] = Field(default=None, alias="apiKeyId")
     action: StrictStr
     target_type: Optional[StrictStr] = Field(default=None, alias="targetType")
     target_id: Optional[StrictStr] = Field(default=None, alias="targetId")
@@ -43,7 +44,7 @@ class AuditLog(BaseModel):
     metadata: Optional[Dict[str, Any]] = None
     created_at: datetime = Field(alias="createdAt")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["id", "actorId", "actorEmail", "organizationId", "action", "targetType", "targetId", "statusCode", "errorMessage", "ipAddress", "userAgent", "source", "metadata", "createdAt"]
+    __properties: ClassVar[List[str]] = ["id", "actorId", "actorEmail", "organizationId", "apiKeyId", "action", "targetType", "targetId", "statusCode", "errorMessage", "ipAddress", "userAgent", "source", "metadata", "createdAt"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -107,6 +108,7 @@ class AuditLog(BaseModel):
             "actorId": obj.get("actorId"),
             "actorEmail": obj.get("actorEmail"),
             "organizationId": obj.get("organizationId"),
+            "apiKeyId": obj.get("apiKeyId"),
             "action": obj.get("action"),
             "targetType": obj.get("targetType"),
             "targetId": obj.get("targetId"),

--- a/libs/api-client/src/models/audit-log.ts
+++ b/libs/api-client/src/models/audit-log.ts
@@ -47,6 +47,12 @@ export interface AuditLog {
    * @type {string}
    * @memberof AuditLog
    */
+  apiKeyId?: string
+  /**
+   *
+   * @type {string}
+   * @memberof AuditLog
+   */
   action: string
   /**
    *


### PR DESCRIPTION
## Description

Adds an `apiKeyId` property to audit log entries to track which API key was used for a given request.

This enhancement allows for better traceability and auditing of actions performed via API keys. The `apiKeyId` is a composite identifier (`${organizationId}:${userId}:${name}`) and is nullable, as not all audit log entries originate from API key authenticated requests.

## Documentation

- [x] This change requires a documentation update
- [ ] I have made corresponding changes to the documentation

## Related Issue(s)

This PR addresses issue #X

## Screenshots

N/A

## Notes

The `apiKeyId` is derived from the API key's composite primary key and is stored as a nullable string in the audit log. A database migration is included to add the `apiKeyId` column to the `audit_log` table.

---
[Slack Thread](https://asdf-gbj9121.slack.com/archives/D09KZH258LD/p1762471878970849?thread_ts=1762471878.970849&cid=D09KZH258LD)

<a href="https://cursor.com/background-agent?bcId=bc-350e54d0-aafa-4402-8c4c-04d566e2e9d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-350e54d0-aafa-4402-8c4c-04d566e2e9d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

