### PR TITLE
auto-fix: Fix context canceled errors in daytona-proxy-toolbox last activity cache update. In the file apps/pr

### DIFF
--- a/apps/proxy/pkg/proxy/get_sandbox_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_target.go
@@ -306,7 +306,7 @@ func (p *Proxy) parseHost(host string) (targetPort string, sandboxIdOrSignedToke
 // If shouldPollUpdate is true, it starts a goroutine that updates every 50 seconds.
 func (p *Proxy) updateLastActivity(ctx context.Context, sandboxId string, shouldPollUpdate bool, doneCh chan struct{}) {
 	// Prevent frequent updates by caching the last update
-	cached, err := p.sandboxLastActivityUpdateCache.Has(ctx, sandboxId)
+	cached, err := p.sandboxLastActivityUpdateCache.Has(context.Background(), sandboxId)
 	if err != nil {
 		// If cache doesn't work, skip the update to avoid spamming the API
 		log.Errorf("failed to check last activity update cache for sandbox %s: %v", sandboxId, err)
@@ -327,7 +327,7 @@ func (p *Proxy) updateLastActivity(ctx context.Context, sandboxId string, should
 		}
 
 		// Expire a bit before the poll interval to avoid skipping one interval
-		err = p.sandboxLastActivityUpdateCache.Set(ctx, sandboxId, true, pollInterval-5*time.Second)
+		err = p.sandboxLastActivityUpdateCache.Set(context.Background(), sandboxId, true, pollInterval-5*time.Second)
 		if err != nil {
 			log.Errorf("failed to set last activity update cache for sandbox %s: %v", sandboxId, err)
 		}


### PR DESCRIPTION
## Automated Fix

**Issue:** Fix context canceled errors in daytona-proxy-toolbox last activity cache update. In the file apps/proxy/pkg/proxy/get_sandbox_target.go, the updateLastActivity function passes the HTTP request context to cache operations (Has and Set calls on sandboxLastActivityUpdateCache). When the HTTP request ends, the context is canceled and the cache write fails. Replace the request context with context.Background() for these cache operations since they are fire-and-forget.

**Monitoring context:**
```
317 errors/hour in Loki logs: failed to set last activity update cache for sandbox <uuid>: context canceled
```

**Changes:**
```
apps/proxy/pkg/proxy/get_sandbox_target.go | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

_This PR was created automatically by the Daytona Ops Agent._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: swaps the request-scoped context for `context.Background()` in last-activity cache `Has`/`Set` calls to prevent benign cache failures when HTTP requests end; behavior is otherwise unchanged.
> 
> **Overview**
> Prevents spurious `context canceled` errors during sandbox last-activity polling by decoupling `sandboxLastActivityUpdateCache` operations from the request lifecycle.
> 
> In `updateLastActivity` (`get_sandbox_target.go`), cache `Has`/`Set` now use `context.Background()` instead of the incoming request context, while the actual `UpdateLastActivity` API call still uses the provided context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74fdedb74ffece3da5989e4a563d971a1e3b630a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->