### PR TITLE
auto-fix: Fix unhandled AggregateError in RunnerAdapterV0.sandboxInfo during sandbox archive. When the runner 

### DIFF
--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -140,6 +140,13 @@ export class RunnerAdapterV0 implements RunnerAdapter {
         return response
       },
       (error) => {
+        // Handle AggregateError (thrown when runner is unreachable with multiple connection failures)
+        if (error instanceof AggregateError) {
+          const underlyingErrors = error.errors.map(err => err.message || String(err)).join(', ')
+          const errorMessage = `Runner unreachable: ${underlyingErrors}`
+          throw new RunnerApiError(errorMessage, undefined, 'AGGREGATE_ERROR')
+        }
+
         const errorMessage = error.response?.data?.message || error.response?.data || error.message || String(error)
         const statusCode = error.response?.data?.statusCode || error.response?.status || error.status
         const code = error.response?.data?.code || (error as any).code || (error as any).cause?.code || ''


### PR DESCRIPTION
## Automated Fix

**Issue:** Fix unhandled AggregateError in RunnerAdapterV0.sandboxInfo during sandbox archive. When the runner is unreachable (DNS failure, multiple connection failures), Axios throws an AggregateError which is not caught by the error handling in RunnerAdapterV0. The code wraps Axios errors into RunnerApiError but does not handle AggregateError specifically. Add proper AggregateError handling in the Axios request wrapper — catch AggregateError, extract the underlying error messages, and wrap them into a RunnerApiError with a clear message like "Runner unreachable: <underlying errors>".

**Monitoring context:**
```
9 AggregateError instances in last 2h from SandboxManager -> SandboxArchiveAction -> RunnerAdapterV0.sandboxInfo. Stack: RunnerApiError: AggregateError at RunnerAdapterV0 sandboxInfo. The error propagates unhandled, causing sandbox archive operations to fail without a clear error message.
```

**Changes:**
```
apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts | 7 +++++++
 1 file changed, 7 insertions(+)
```

_This PR was created automatically by the Daytona Ops Agent._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to response interceptor error handling; main impact is altering error messaging/codes when the runner is unreachable via multiple connection failures.
> 
> **Overview**
> Improves runner call error handling by explicitly catching Axios `AggregateError` cases (e.g., multiple connection/DNS failures) and rethrowing them as a `RunnerApiError` with a consolidated "Runner unreachable" message and `AGGREGATE_ERROR` code.
> 
> All other Axios errors continue to be wrapped as before, but this prevents unhandled aggregate connection failures from bubbling up during operations like `sandboxInfo` (notably during sandbox archive).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cd25e7c1c8721f410704eca84749f6057b31bae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->