### PR TITLE
auto-fix: Fix SnapshotManager.propagate crashing when no internal registry is configured for a snapshot in a r

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -303,7 +303,8 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
         runnersToPropagateTo.map(async (runner) => {
           const internalRegistry = internalRegistriesMap.get(runner.region)
           if (!internalRegistry) {
-            throw new Error(`No internal registry found for snapshot ${snapshot.ref} in region ${runner.region}`)
+            this.logger.warn(`No internal registry found for snapshot ${snapshot.ref} in region ${runner.region}. Skipping this runner.`)
+            return
           }
 
           const snapshotRunner = await this.runnerService.getSnapshotRunner(runner.id, snapshot.ref)
@@ -383,9 +384,13 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
         runner.region,
       )
       if (!internalRegistry) {
-        throw new Error(
-          `No internal registry found for snapshot ${snapshotRunner.snapshotRef} in region ${runner.region}`,
+        this.logger.warn(
+          `No internal registry found for snapshot ${snapshotRunner.snapshotRef} in region ${runner.region}. Marking snapshot runner as error.`,
         )
+        snapshotRunner.state = SnapshotRunnerState.ERROR
+        snapshotRunner.errorReason = `No internal registry found for snapshot ${snapshotRunner.snapshotRef} in region ${runner.region}`
+        await this.snapshotRunnerRepository.save(snapshotRunner)
+        return
       }
       await this.pullSnapshotRunner(runner, snapshotRunner.snapshotRef, internalRegistry)
       return


### PR DESCRIPTION
## Automated Fix

**Issue:** Fix SnapshotManager.propagate crashing when no internal registry is configured for a snapshot in a region. The code throws "No internal registry found for snapshot vm-experimental in region us" instead of handling the missing registry gracefully. The fix: in the SnapshotManager propagate method (or the code that maps snapshots to registries), when no internal registry is found for a snapshot+region combination, log a warning and skip that region instead of throwing an error that crashes the entire propagation.

**Monitoring context:**
```
4 errors in last 6h from SnapshotManager: No internal registry found for snapshot vm-experimental in region us. Stack trace shows SnapshotManager.propagate -> Array.map at /daytona/dist/apps/api/main.js. The error is thrown inside a .map() call, meaning one missing registry causes the entire propagation batch to fail.
```

**Changes:**
```
apps/api/src/sandbox/managers/snapshot.manager.ts | 11 ++++++++---
 1 file changed, 8 insertions(+), 3 deletions(-)
```

_This PR was created automatically by the Daytona Ops Agent._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: replaces throw paths with warning+skip/error-state handling when an internal registry is missing, reducing batch failures but potentially leaving some runners without propagated snapshots until configuration is fixed.
> 
> **Overview**
> Prevents `SnapshotManager` snapshot propagation from crashing when a region lacks an internal registry.
> 
> During `propagateSnapshotToRunners`, missing `internalRegistry` for a runner now **logs a warning and skips** that runner instead of throwing. When retrying a `PULLING_SNAPSHOT` runner after the retry timeout, missing registry now **marks the `SnapshotRunner` as `ERROR` with an `errorReason`** and returns, rather than throwing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07599cf2521852276ac60254051eda95ef6e3952. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->