### PR TITLE
auto-fix: Add exponential backoff to RunnerAdapterV0 HTTP request retries. Currently, the RunnerAdapterV0 retr

### DIFF
--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -110,10 +110,14 @@ export class RunnerAdapterV0 implements RunnerAdapter {
 
     const retryErrorMap = new WeakMap<AxiosError, string>()
 
-    // Configure axios-retry to handle network errors
+    // Configure axios-retry to handle network errors with exponential backoff
     axiosRetry(axiosInstance, {
       retries: 3,
-      retryDelay: axiosRetry.exponentialDelay,
+      retryDelay: (retryCount: number) => {
+        // Exponential backoff: 1s, 2s, 4s for attempts 1, 2, 3
+        const delay = Math.pow(2, retryCount - 1) * 1000
+        return delay
+      },
       retryCondition: (error) => {
         // Check if error code or message matches any retryable error
         const matchedErrorCode = RETRYABLE_NETWORK_ERROR_CODES.find(
@@ -129,8 +133,9 @@ export class RunnerAdapterV0 implements RunnerAdapter {
         return false
       },
       onRetry: (retryCount, error, requestConfig) => {
+        const delayUsed = Math.pow(2, retryCount - 1) * 1000 // Calculate the delay that was just used
         this.logger.warn(
-          `Retrying request due to ${retryErrorMap.get(error)} (attempt ${retryCount}): ${requestConfig.method?.toUpperCase()} ${requestConfig.url}`,
+          `Retrying request due to ${retryErrorMap.get(error)} (attempt ${retryCount}) after ${delayUsed}ms delay: ${requestConfig.method?.toUpperCase()} ${requestConfig.url}`,
         )
       },
     })


### PR DESCRIPTION
## Automated Fix

**Issue:** Add exponential backoff to RunnerAdapterV0 HTTP request retries. Currently, the RunnerAdapterV0 retries failed requests to runners (e.g. GET /sandboxes/<id>) up to 3 times on ETIMEDOUT errors, but the retries appear to happen immediately without backoff. This hammers already-struggling runners. Add exponential backoff (e.g. 1s, 2s, 4s) between retry attempts in the Axios retry/interceptor configuration in the RunnerAdapterV0 class.

**Monitoring context:**
```
Loki warns show RunnerAdapterV0: Retrying request due to ETIMEDOUT (attempt 3) for many sandboxes over the last 6h. Multiple sandboxes hit attempt 3, suggesting the runner is under load and immediate retries make it worse. The retry logic is in the RunnerAdapterV0 TypeScript class in apps/api/src/sandbox/runner-adapter/.
```

**Changes:**
```
apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts | 11 ++++++++---
 1 file changed, 8 insertions(+), 3 deletions(-)
```

_This PR was created automatically by the Daytona Ops Agent._