### PR TITLE
auto-fix: Add configurable dial timeout to the daytona-proxy reverse proxy. The proxy gets frequent connection

### DIFF
--- a/apps/proxy/cmd/proxy/config/config.go
+++ b/apps/proxy/cmd/proxy/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	TLSKeyFile            string             `envconfig:"TLS_KEY_FILE"`
 	EnableTLS             bool               `envconfig:"ENABLE_TLS"`
 	DaytonaApiUrl         string             `envconfig:"DAYTONA_API_URL" validate:"required"`
+	DialTimeoutSec        int                `envconfig:"DIAL_TIMEOUT_SEC"`
 	Oidc                  OidcConfig         `envconfig:"OIDC"`
 	Redis                 *cache.RedisConfig `envconfig:"REDIS"`
 	ToolboxOnlyMode       bool               `envconfig:"TOOLBOX_ONLY_MODE"`
@@ -78,6 +79,10 @@ func GetConfig() (*Config, error) {
 
 	if config.ShutdownTimeoutSec == 0 {
 		config.ShutdownTimeoutSec = 60 * 60 // default to 1 hour
+	}
+
+	if config.DialTimeoutSec == 0 {
+		config.DialTimeoutSec = 10 // default to 10 seconds
 	}
 
 	if config.Redis != nil {

--- a/apps/proxy/pkg/proxy/proxy.go
+++ b/apps/proxy/pkg/proxy/proxy.go
@@ -59,6 +59,7 @@ type Proxy struct {
 	config       *config.Config
 	secureCookie *securecookie.SecureCookie
 	cookieDomain *string
+	transport    *http.Transport
 
 	apiclient                      *apiclient.APIClient
 	runnerCache                    common_cache.ICache[RunnerInfo]
@@ -79,6 +80,7 @@ func StartProxy(ctx context.Context, config *config.Config) error {
 		proxy.cookieDomain = &cookieDomain
 	}
 
+	proxy.transport = common_proxy.NewProxyTransport(config.DialTimeoutSec)
 	proxy.apiclient = config.ApiClient
 
 	if config.Redis != nil {
@@ -188,12 +190,12 @@ func StartProxy(ctx context.Context, config *config.Config) error {
 					}
 
 					if regexp.MustCompile(`^/snapshots/[\w-]+/build-logs$`).MatchString(ctx.Request.URL.Path) {
-						common_proxy.NewProxyRequestHandler(proxy.getSnapshotTarget, nil)(ctx)
+						common_proxy.NewProxyRequestHandlerWithTransport(proxy.getSnapshotTarget, nil, proxy.transport)(ctx)
 						return
 					}
 
 					if regexp.MustCompile(`^/sandboxes/[\w-]+/build-logs$`).MatchString(ctx.Request.URL.Path) {
-						common_proxy.NewProxyRequestHandler(proxy.getSandboxBuildTarget, nil)(ctx)
+						common_proxy.NewProxyRequestHandlerWithTransport(proxy.getSandboxBuildTarget, nil, proxy.transport)(ctx)
 						return
 					}
 				}
@@ -218,7 +220,7 @@ func StartProxy(ctx context.Context, config *config.Config) error {
 					return nil
 				}
 
-				common_proxy.NewProxyRequestHandler(proxy.GetProxyTarget, modifyResponse)(ctx)
+				common_proxy.NewProxyRequestHandlerWithTransport(proxy.GetProxyTarget, modifyResponse, proxy.transport)(ctx)
 				return
 			}
 
@@ -232,7 +234,7 @@ func StartProxy(ctx context.Context, config *config.Config) error {
 			return
 		}
 
-		common_proxy.NewProxyRequestHandler(proxy.GetProxyTarget, nil)(ctx)
+		common_proxy.NewProxyRequestHandlerWithTransport(proxy.GetProxyTarget, nil, proxy.transport)(ctx)
 	})
 
 	httpServer := &http.Server{

--- a/libs/common-go/pkg/proxy/proxy.go
+++ b/libs/common-go/pkg/proxy/proxy.go
@@ -13,11 +13,24 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-var proxyTransport = &http.Transport{
+// NewProxyTransport creates an HTTP transport with configurable dial timeout
+func NewProxyTransport(dialTimeoutSec int) *http.Transport {
+	return &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 100,
+		DialContext: (&net.Dialer{
+			KeepAlive: 30 * time.Second,
+			Timeout:   time.Duration(dialTimeoutSec) * time.Second,
+		}).DialContext,
+	}
+}
+
+var defaultProxyTransport = &http.Transport{
 	MaxIdleConns:        100,
 	MaxIdleConnsPerHost: 100,
 	DialContext: (&net.Dialer{
 		KeepAlive: 30 * time.Second,
+		Timeout:   10 * time.Second,
 	}).DialContext,
 }
 
@@ -37,6 +50,12 @@ var proxyTransport = &http.Transport{
 //	@Failure		500			{object}	string	"Internal server error"
 //	@Router			/workspaces/{workspaceId}/{projectId}/toolbox/{path} [get]
 func NewProxyRequestHandler(getProxyTarget func(*gin.Context) (targetUrl *url.URL, extraHeaders map[string]string, err error), modifyResponse func(*http.Response) error) gin.HandlerFunc {
+	return NewProxyRequestHandlerWithTransport(getProxyTarget, modifyResponse, nil)
+}
+
+// NewProxyRequestHandlerWithTransport creates a proxy handler with a custom transport.
+// If transport is nil, a default transport will be used.
+func NewProxyRequestHandlerWithTransport(getProxyTarget func(*gin.Context) (targetUrl *url.URL, extraHeaders map[string]string, err error), modifyResponse func(*http.Response) error, transport http.RoundTripper) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		target, extraHeaders, err := getProxyTarget(ctx)
 		if err != nil {
@@ -46,6 +65,10 @@ func NewProxyRequestHandler(getProxyTarget func(*gin.Context) (targetUrl *url.UR
 
 		if target == nil {
 			return
+		}
+
+		if transport == nil {
+			transport = defaultProxyTransport
 		}
 
 		reverseProxy := &httputil.ReverseProxy{
@@ -63,7 +86,7 @@ func NewProxyRequestHandler(getProxyTarget func(*gin.Context) (targetUrl *url.UR
 					req.Header.Add(key, value)
 				}
 			},
-			Transport:      proxyTransport,
+			Transport:      transport,
 			ModifyResponse: modifyResponse,
 		}
 


### PR DESCRIPTION
## Automated Fix

**Issue:** Add configurable dial timeout to the daytona-proxy reverse proxy. The proxy gets frequent connection timeout errors when dialing sandbox IPs (dial tcp <IP>:3000: connect: connection timed out). The default Go net.Dialer timeout is too long (30s), causing proxy goroutines to hang. Add a configurable dial timeout (default 10s) to the reverse proxy transport in the proxy code. Look in apps/proxy/ for where the httputil.ReverseProxy or http.Transport is configured and add a DialContext with a reasonable timeout.

**Monitoring context:**
```
56 connection timeout errors in daytona-proxy in the last 2h: http: proxy error: dial tcp <IP>:3000: connect: connection timed out. These happen when sandbox containers become unreachable. The long default timeout (30s) ties up proxy resources. A shorter configurable timeout would allow faster failover and better resource utilization.
```

**Changes:**
```
apps/proxy/cmd/proxy/config/config.go |  5 +++++
 apps/proxy/pkg/proxy/proxy.go         | 10 ++++++----
 libs/common-go/pkg/proxy/proxy.go     | 27 +++++++++++++++++++++++++--
 3 files changed, 36 insertions(+), 6 deletions(-)
```

_This PR was created automatically by the Daytona Ops Agent._