### PR TITLE
auto-fix: Improve error message when sandbox desired state processing fails with ETIMEDOUT. Currently when pro

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -852,7 +852,17 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
             }
           }
         } catch (error) {
-          this.logger.error(`Error processing desired state for sandbox ${sandboxId}:`, error)
+          // Extract root cause from error chain
+          const rootCause = this.extractRootCause(error)
+          const errorMessage = `Error processing desired state for sandbox ${sandboxId}${rootCause ? ` (${rootCause})` : ''}`
+          
+          // Log at warn level for transient network issues, error level otherwise
+          const isTransientNetworkIssue = this.isTransientNetworkError(error)
+          if (isTransientNetworkIssue) {
+            this.logger.warn(errorMessage, error)
+          } else {
+            this.logger.error(errorMessage, error)
+          }
 
           const { recoverable, errorReason } = sanitizeSandboxError(error)
 


### PR DESCRIPTION
## Automated Fix

**Issue:** Improve error message when sandbox desired state processing fails with ETIMEDOUT. Currently when processing desired state for a sandbox fails because the runner times out, the error message is generic: Error processing desired state for sandbox <id>. The error handler in the desired state processor should include the underlying cause (ETIMEDOUT, runner unreachable, etc.) in the error message and log at warn level instead of error level for transient network issues. Look in apps/api/src/sandbox/ for the desired state processing logic — likely in a file like sandbox-desired-state or sandbox-state-machine.

**Monitoring context:**
```
Multiple occurrences in the last 6h: Error processing desired state for sandbox <id> with underlying ETIMEDOUT from RunnerAdapterV0. The current logging does not include the underlying error cause, making it hard to distinguish between transient network issues and real bugs. The error handler should extract and log the root cause from nested error chains.
```

**Changes:**
```
apps/api/src/sandbox/managers/sandbox.manager.ts | 12 +++++++++++-
 1 file changed, 11 insertions(+), 1 deletion(-)
```

_This PR was created automatically by the Daytona Ops Agent._