### PR TITLE
fix(runner): use local error vars in goroutines to avoid data race

### DIFF
--- a/apps/runner/pkg/docker/create.go
+++ b/apps/runner/pkg/docker/create.go
@@ -135,25 +135,25 @@ func (d *DockerClient) Create(ctx context.Context, sandboxDto dto.CreateSandboxD
 	ip := common.GetContainerIpAddress(ctx, runningContainer)
 	if sandboxDto.NetworkBlockAll != nil && *sandboxDto.NetworkBlockAll {
 		go func() {
-			err = d.netRulesManager.SetNetworkRules(containerShortId, ip, "")
-			if err != nil {
-				d.logger.ErrorContext(ctx, "Failed to update sandbox network settings", "error", err)
+			setErr := d.netRulesManager.SetNetworkRules(containerShortId, ip, "")
+			if setErr != nil {
+				d.logger.ErrorContext(ctx, "Failed to update sandbox network settings", "error", setErr)
 			}
 		}()
 	} else if sandboxDto.NetworkAllowList != nil && *sandboxDto.NetworkAllowList != "" {
 		go func() {
-			err = d.netRulesManager.SetNetworkRules(containerShortId, ip, *sandboxDto.NetworkAllowList)
-			if err != nil {
-				d.logger.ErrorContext(ctx, "Failed to update sandbox network settings", "error", err)
+			setErr := d.netRulesManager.SetNetworkRules(containerShortId, ip, *sandboxDto.NetworkAllowList)
+			if setErr != nil {
+				d.logger.ErrorContext(ctx, "Failed to update sandbox network settings", "error", setErr)
 			}
 		}()
 	}
 
 	if sandboxDto.Metadata != nil && sandboxDto.Metadata["limitNetworkEgress"] == "true" {
 		go func() {
-			err = d.netRulesManager.SetNetworkLimiter(containerShortId, ip)
-			if err != nil {
-				d.logger.ErrorContext(ctx, "Failed to update sandbox network settings", "error", err)
+			limiterErr := d.netRulesManager.SetNetworkLimiter(containerShortId, ip)
+			if limiterErr != nil {
+				d.logger.ErrorContext(ctx, "Failed to update sandbox network settings", "error", limiterErr)
 			}
 		}()
 	}


### PR DESCRIPTION
## Summary

Fix data race on shared err variable in apps/runner/pkg/docker/create.go.

**Root cause:** Root cause: The goroutines use the outer function err variable instead of local vars.

**Fix:** The fix: In each goroutine, replace err = ... with a local variable:

## Evidence

```
Data race detected by go build -race. Multiple goroutines write to shared err variable in Create().
```

## Changes

```
apps/runner/pkg/docker/create.go | 18 +++++++++---------
 1 file changed, 9 insertions(+), 9 deletions(-)
```

## Agent Summary

Perfect! The fix has been successfully applied. Let me summarize what I changed:
## Summary
I successfully fixed the data race issue in `/home/daytona/repo/apps/runner/pkg/docker/create.go` by making the following minimal, targeted changes:
### Changes Made:
1. **Line 138**: Changed `err = d.netRulesManager.SetNetworkRules(containerShortId, ip, "")` to `setErr := d.netRulesManager.SetNetworkRules(containerShortId, ip, "")` and updated the corresponding error check to use `setErr`.
2. **Line 145**: Changed `err = d.netRulesManager.SetNetworkRules(containerShortId, ip, *sandboxDto.NetworkAllowList)` to `setErr := d.netRulesManager.SetNetworkRules(containerShortId, ip, *sandboxDto.NetworkAllowList)` and updated the corresponding error check to use `setErr`.
3. **Line 154**: Changed `err = d.netRulesManager.SetNetworkLimiter(containerShortId, ip)` to `limiterErr := d.netRulesManager.SetNetworkLimiter(containerShortId, ip)` and updated the corresponding error check to use `limiterErr`.
### 

---
_Automated by [Daytona Ops Agent](https://github.com/daytonaio/daytona) — detected via production monitoring._