### PR TITLE
fix: resolve route shadowing causing QueryFailedError in RunnerAccessGuard

### DIFF
--- a/apps/api/src/sandbox/controllers/runner.controller.ts
+++ b/apps/api/src/sandbox/controllers/runner.controller.ts
@@ -139,6 +139,50 @@ export class RunnerController {
     return this.runnerService.findOneFullOrFail(runnerContext.runnerId)
   }
 
+  @Get('/by-sandbox/:sandboxId')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Get runner by sandbox ID',
+    operationId: 'getRunnerBySandboxId',
+  })
+  @ApiResponse({
+    status: 200,
+    type: RunnerFullDto,
+  })
+  @UseGuards(OrGuard([SystemActionGuard, ProxyGuard, SshGatewayGuard, RegionSandboxAccessGuard]))
+  @RequiredApiRole([SystemRole.ADMIN])
+  async getRunnerBySandboxId(@Param('sandboxId') sandboxId: string): Promise<RunnerFullDto> {
+    const runner = await this.runnerService.findBySandboxId(sandboxId)
+
+    if (!runner) {
+      throw new NotFoundException('Runner not found')
+    }
+
+    return RunnerFullDto.fromRunner(runner)
+  }
+
+  @Get('/by-snapshot-ref')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Get runners by snapshot ref',
+    operationId: 'getRunnersBySnapshotRef',
+  })
+  @ApiResponse({
+    status: 200,
+    type: [RunnerSnapshotDto],
+  })
+  @ApiQuery({
+    name: 'ref',
+    description: 'Snapshot ref',
+    type: String,
+    required: true,
+  })
+  @UseGuards(OrGuard([SystemActionGuard, ProxyGuard, SshGatewayGuard]))
+  @RequiredApiRole([SystemRole.ADMIN, 'proxy', 'ssh-gateway'])
+  async getRunnersBySnapshotRef(@Query('ref') ref: string): Promise<RunnerSnapshotDto[]> {
+    return this.runnerService.getRunnersBySnapshotRef(ref)
+  }
+
   @Get(':id')
   @HttpCode(200)
   @ApiOperation({
@@ -301,50 +345,6 @@ export class RunnerController {
   @RequireFlagsEnabled({ flags: [{ flagKey: FeatureFlags.ORGANIZATION_INFRASTRUCTURE, defaultValue: false }] })
   async delete(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
     return this.runnerService.remove(id)
-  }
-
-  @Get('/by-sandbox/:sandboxId')
-  @HttpCode(200)
-  @ApiOperation({
-    summary: 'Get runner by sandbox ID',
-    operationId: 'getRunnerBySandboxId',
-  })
-  @ApiResponse({
-    status: 200,
-    type: RunnerFullDto,
-  })
-  @UseGuards(OrGuard([SystemActionGuard, ProxyGuard, SshGatewayGuard, RegionSandboxAccessGuard]))
-  @RequiredApiRole([SystemRole.ADMIN])
-  async getRunnerBySandboxId(@Param('sandboxId') sandboxId: string): Promise<RunnerFullDto> {
-    const runner = await this.runnerService.findBySandboxId(sandboxId)
-
-    if (!runner) {
-      throw new NotFoundException('Runner not found')
-    }
-
-    return RunnerFullDto.fromRunner(runner)
-  }
-
-  @Get('/by-snapshot-ref')
-  @HttpCode(200)
-  @ApiOperation({
-    summary: 'Get runners by snapshot ref',
-    operationId: 'getRunnersBySnapshotRef',
-  })
-  @ApiResponse({
-    status: 200,
-    type: [RunnerSnapshotDto],
-  })
-  @ApiQuery({
-    name: 'ref',
-    description: 'Snapshot ref',
-    type: String,
-    required: true,
-  })
-  @UseGuards(OrGuard([SystemActionGuard, ProxyGuard, SshGatewayGuard]))
-  @RequiredApiRole([SystemRole.ADMIN, 'proxy', 'ssh-gateway'])
-  async getRunnersBySnapshotRef(@Query('ref') ref: string): Promise<RunnerSnapshotDto[]> {
-    return this.runnerService.getRunnersBySnapshotRef(ref)
   }
 
   @Post('healthcheck')

--- a/apps/api/src/sandbox/guards/runner-access.guard.ts
+++ b/apps/api/src/sandbox/guards/runner-access.guard.ts
@@ -30,9 +30,15 @@ export class RunnerAccessGuard implements CanActivate {
     private readonly regionService: RegionService,
   ) {}
 
+  private static readonly UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest()
     const runnerId: string = request.params.runnerId || request.params.id
+
+    if (!runnerId || !RunnerAccessGuard.UUID_REGEX.test(runnerId)) {
+      throw new NotFoundException('Runner not found')
+    }
 
     // TODO: initialize authContext safely
     const authContext: BaseAuthContext = request.user


### PR DESCRIPTION
## Summary
- **Production bug**: `GET /runners/by-snapshot-ref` and `GET /runners/by-sandbox/:sandboxId` were shadowed by the parameterized `GET /runners/:id` route because NestJS matches routes in declaration order. Requests to these endpoints were captured by `:id`, passing literal strings like `"by-snapshot-ref"` to the `RunnerAccessGuard` which attempted a PostgreSQL UUID lookup, causing `QueryFailedError("invalid input syntax for type uuid")` continuously across all API pods.
- **Fix 1 — Route reordering**: Moved `@Get("/by-sandbox/:sandboxId")` and `@Get("/by-snapshot-ref")` declarations before `@Get(":id")` in `RunnerController` so static paths match before the wildcard.
- **Fix 2 — Guard-level UUID validation**: Added a UUID format regex check in `RunnerAccessGuard.canActivate()` as defense-in-depth. Since NestJS guards run before parameter pipes (`ParseUUIDPipe`), the guard was the first code to touch the invalid value. Now it rejects non-UUID values immediately with `NotFoundException` before any database query.

## Reproduction
```bash
curl -s https://<api>/api/runners/by-snapshot-ref?ref=some-snapshot -H "Authorization: Bearer <token>"
# Before fix: 500 QueryFailedError logged, 404 returned
# After fix: correctly routed to getRunnersBySnapshotRef handler
```

## Test plan
- [ ] Verify `GET /runners/by-snapshot-ref?ref=<ref>` returns runner snapshot data (not 404)
- [ ] Verify `GET /runners/by-sandbox/<sandboxId>` returns runner data (not 404)
- [ ] Verify `GET /runners/<valid-uuid>` still works as expected
- [ ] Verify `GET /runners/<non-uuid-string>` returns clean 404 (no DB error in logs)