### PR TITLE
fix: use Promise.allSettled in sync crons to prevent single-sandbox failures from aborting batch

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox.manager.ts
+++ b/apps/api/src/sandbox/managers/sandbox.manager.ts
@@ -701,18 +701,12 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
             // Limit concurrent processing to avoid overwhelming the system
             if (pendingProcesses.length >= 10) {
               stream.pause()
-              Promise.allSettled(pendingProcesses.splice(0, pendingProcesses.length))
-                .then(() => stream.resume())
-                .catch(reject)
+              Promise.allSettled(pendingProcesses.splice(0, pendingProcesses.length)).then(() => stream.resume())
             }
           })
 
           stream.on('end', () => {
-            Promise.all(pendingProcesses)
-              .then(() => {
-                resolve()
-              })
-              .catch(reject)
+            Promise.allSettled(pendingProcesses).then(() => resolve())
           })
 
           stream.on('error', reject)
@@ -748,12 +742,15 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
       },
     })
 
-    await Promise.all(
-      sandboxes.map(async (sandbox) => {
-        this.syncInstanceState(sandbox.id)
-      }),
-    )
-    await this.redisLockProvider.unlock(lockKey)
+    try {
+      await Promise.allSettled(
+        sandboxes.map(async (sandbox) => {
+          await this.syncInstanceState(sandbox.id)
+        }),
+      )
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
   }
 
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'sync-archived-completed-states' })
@@ -777,12 +774,15 @@ export class SandboxManager implements TrackableJobExecutions, OnApplicationShut
       },
     })
 
-    await Promise.allSettled(
-      sandboxes.map(async (sandbox) => {
-        await this.syncInstanceState(sandbox.id)
-      }),
-    )
-    await this.redisLockProvider.unlock(lockKey)
+    try {
+      await Promise.allSettled(
+        sandboxes.map(async (sandbox) => {
+          await this.syncInstanceState(sandbox.id)
+        }),
+      )
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- **Production bug**: `SandboxManager.syncStates()` used `Promise.all` in the stream `end` handler for the final batch of pending processes, while mid-stream batching correctly used `Promise.allSettled`. A single sandbox sync failure (e.g., `AggregateError` from an unreachable runner) would reject the `Promise.all`, abort the entire sync cycle, and leave remaining sandboxes stuck in inconsistent states.
- **Second bug in `syncArchivedDesiredStates()`**: Missing `await` before `this.syncInstanceState(sandbox.id)` inside the `map` callback, causing `Promise.all` to resolve immediately without waiting for actual syncs. The Redis lock was released while syncs were still running in the background, allowing concurrent cron runs to collide.
- **Third issue**: Both `syncArchivedDesiredStates()` and `syncArchivedCompletedStates()` lacked `try/finally` around lock release, meaning if the Promise itself threw, the lock would never be released until TTL expiry (30 seconds), blocking subsequent cron runs.

### Changes
1. `syncStates()`: Changed `Promise.all` → `Promise.allSettled` in stream `end` handler. Removed dead `.catch(reject)` on mid-stream `Promise.allSettled` call.
2. `syncArchivedDesiredStates()`: Added missing `await`, changed `Promise.all` → `Promise.allSettled`, wrapped in `try/finally` for lock release.
3. `syncArchivedCompletedStates()`: Wrapped in `try/finally` for lock release.

## Test plan
- [ ] Verify sandbox state sync continues processing remaining sandboxes when one fails
- [ ] Verify `syncArchivedDesiredStates` properly awaits all syncs before releasing lock
- [ ] Verify lock is always released even if Promise operations throw
- [ ] Check production logs for reduction in `AggregateError` and orphaned sandbox states