### PR TITLE
fix: mark transient network errors as recoverable in sandbox state sync

### DIFF
--- a/apps/api/src/sandbox/errors/runner-api-error.ts
+++ b/apps/api/src/sandbox/errors/runner-api-error.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+const CONNECTION_ERROR_CODES = ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EHOSTUNREACH', 'ENETUNREACH', 'EAI_AGAIN']
+
 export class RunnerApiError extends Error {
   constructor(
     message: string,
@@ -11,5 +13,9 @@ export class RunnerApiError extends Error {
   ) {
     super(message)
     this.name = 'RunnerApiError'
+  }
+
+  isConnectionError(): boolean {
+    return CONNECTION_ERROR_CODES.some((c) => this.code === c || this.message?.includes(c))
   }
 }

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-archive.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-archive.action.ts
@@ -18,6 +18,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter'
 import { SandboxEvents } from '../../constants/sandbox-events.constants'
 import { SandboxBackupCreatedEvent } from '../../events/sandbox-backup-created.event'
 import { WithSpan } from '../../../common/decorators/otel.decorator'
+import { RunnerApiError } from '../../errors/runner-api-error'
 
 @Injectable()
 export class SandboxArchiveAction extends SandboxAction {
@@ -121,6 +122,10 @@ export class SandboxArchiveAction extends SandboxAction {
 
         await this.updateSandboxState(sandbox, SandboxState.ARCHIVED, lockCode, null)
         return DONT_SYNC_AGAIN
+      }
+
+      if (error instanceof RunnerApiError && error.isConnectionError()) {
+        throw Object.assign(error, { recoverable: true, errorReason: error.message })
       }
 
       throw error

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
@@ -13,6 +13,7 @@ import { RunnerAdapterFactory } from '../../runner-adapter/runnerAdapter'
 import { SandboxRepository } from '../../repositories/sandbox.repository'
 import { LockCode, RedisLockProvider } from '../../common/redis-lock.provider'
 import { WithSpan } from '../../../common/decorators/otel.decorator'
+import { RunnerApiError } from '../../errors/runner-api-error'
 
 @Injectable()
 export class SandboxDestroyAction extends SandboxAction {
@@ -58,10 +59,13 @@ export class SandboxDestroyAction extends SandboxAction {
 
       return SYNC_AGAIN
     } catch (error) {
-      //  if the sandbox is not found on runner, it is already destroyed
       if (error.response?.status === 404 || error.statusCode === 404) {
         await this.updateSandboxState(sandbox, SandboxState.DESTROYED, lockCode)
         return DONT_SYNC_AGAIN
+      }
+
+      if (error instanceof RunnerApiError && error.isConnectionError()) {
+        throw Object.assign(error, { recoverable: true, errorReason: error.message })
       }
 
       throw error

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-stop.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-stop.action.ts
@@ -14,6 +14,7 @@ import { RunnerAdapterFactory } from '../../runner-adapter/runnerAdapter'
 import { SandboxRepository } from '../../repositories/sandbox.repository'
 import { LockCode, RedisLockProvider } from '../../common/redis-lock.provider'
 import { WithSpan } from '../../../common/decorators/otel.decorator'
+import { RunnerApiError } from '../../errors/runner-api-error'
 
 @Injectable()
 export class SandboxStopAction extends SandboxAction {
@@ -35,43 +36,48 @@ export class SandboxStopAction extends SandboxAction {
 
     const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
-    if (sandbox.state === SandboxState.STARTED) {
-      // stop sandbox
-      await runnerAdapter.stopSandbox(sandbox.id)
-      await this.updateSandboxState(sandbox, SandboxState.STOPPING, lockCode)
+    try {
+      if (sandbox.state === SandboxState.STARTED) {
+        await runnerAdapter.stopSandbox(sandbox.id)
+        await this.updateSandboxState(sandbox, SandboxState.STOPPING, lockCode)
+        return SYNC_AGAIN
+      }
 
-      //  sync states again immediately for sandbox
+      if (sandbox.state !== SandboxState.STOPPING && sandbox.state !== SandboxState.ERROR) {
+        return DONT_SYNC_AGAIN
+      }
+
+      const sandboxInfo = await runnerAdapter.sandboxInfo(sandbox.id)
+
+      if (sandboxInfo.state === SandboxState.STOPPED) {
+        await this.updateSandboxState(
+          sandbox,
+          SandboxState.STOPPED,
+          lockCode,
+          undefined,
+          undefined,
+          undefined,
+          BackupState.NONE,
+        )
+        return DONT_SYNC_AGAIN
+      } else if (sandboxInfo.state === SandboxState.ERROR) {
+        await this.updateSandboxState(
+          sandbox,
+          SandboxState.ERROR,
+          lockCode,
+          undefined,
+          'Sandbox is in error state on runner',
+        )
+        return DONT_SYNC_AGAIN
+      }
+
       return SYNC_AGAIN
+    } catch (error) {
+      if (error instanceof RunnerApiError && error.isConnectionError()) {
+        throw Object.assign(error, { recoverable: true, errorReason: error.message })
+      }
+
+      throw error
     }
-
-    if (sandbox.state !== SandboxState.STOPPING && sandbox.state !== SandboxState.ERROR) {
-      return DONT_SYNC_AGAIN
-    }
-
-    const sandboxInfo = await runnerAdapter.sandboxInfo(sandbox.id)
-
-    if (sandboxInfo.state === SandboxState.STOPPED) {
-      await this.updateSandboxState(
-        sandbox,
-        SandboxState.STOPPED,
-        lockCode,
-        undefined,
-        undefined,
-        undefined,
-        BackupState.NONE,
-      )
-      return DONT_SYNC_AGAIN
-    } else if (sandboxInfo.state === SandboxState.ERROR) {
-      await this.updateSandboxState(
-        sandbox,
-        SandboxState.ERROR,
-        lockCode,
-        undefined,
-        'Sandbox is in error state on runner',
-      )
-      return DONT_SYNC_AGAIN
-    }
-
-    return SYNC_AGAIN
   }
 }

--- a/apps/api/src/sandbox/utils/sanitize-error.util.ts
+++ b/apps/api/src/sandbox/utils/sanitize-error.util.ts
@@ -3,12 +3,35 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
+const RECOVERABLE_ERROR_CODES = ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EHOSTUNREACH', 'ENETUNREACH', 'EAI_AGAIN']
+
+function isTransientNetworkError(error: any): boolean {
+  if (!error || typeof error !== 'object') return false
+
+  const code = error.code || ''
+  if (RECOVERABLE_ERROR_CODES.includes(code)) return true
+
+  const message = error.message || ''
+  if (RECOVERABLE_ERROR_CODES.some((c) => message.includes(c))) return true
+
+  if (error.name === 'AggregateError' || error.constructor?.name === 'AggregateError') return true
+
+  return false
+}
+
 export function sanitizeSandboxError(error: any): { recoverable: boolean; errorReason: string } {
+  if (typeof error === 'object' && error !== null && isTransientNetworkError(error)) {
+    return { recoverable: true, errorReason: error.message || String(error) }
+  }
+
   if (typeof error === 'string') {
     try {
       const errObj = JSON.parse(error) as { recoverable: boolean; errorReason: string }
       return { recoverable: errObj.recoverable, errorReason: errObj.errorReason }
     } catch {
+      if (RECOVERABLE_ERROR_CODES.some((c) => error.includes(c))) {
+        return { recoverable: true, errorReason: error }
+      }
       return { recoverable: false, errorReason: error }
     }
   } else if (typeof error === 'object' && error !== null && 'recoverable' in error && 'errorReason' in error) {


### PR DESCRIPTION
## Summary
- Production logs show sandboxes permanently stuck in ERROR state due to temporary runner connectivity issues (ECONNREFUSED, ETIMEDOUT, ECONNRESET, AggregateError)
- Updated sanitize-error.util.ts to detect transient network errors and mark them as recoverable
- Added isConnectionError() helper to RunnerApiError
- Added connection error handling to SandboxDestroyAction, SandboxArchiveAction, and SandboxStopAction

## Test plan
- [ ] Verify sandboxes with network errors are marked as recoverable (not permanent ERROR)
- [ ] Verify sandbox sync retries on transient network failures