### PR TITLE
fix: prevent TypeError when dockerfileContent is undefined in snapshot creation

### DIFF
--- a/apps/api/src/sandbox/services/snapshot.service.ts
+++ b/apps/api/src/sandbox/services/snapshot.service.ts
@@ -688,9 +688,11 @@ export class SnapshotService {
     }
   }
 
-  // TODO: revise/cleanup
-  getEntrypointFromDockerfile(dockerfileContent: string): string[] {
-    // Match ENTRYPOINT with either a string or JSON array
+  getEntrypointFromDockerfile(dockerfileContent?: string | null): string[] {
+    if (!dockerfileContent) {
+      return ['sleep', 'infinity']
+    }
+
     const entrypointMatch = dockerfileContent.match(/ENTRYPOINT\s+(.*)/)
     if (entrypointMatch) {
       const rawEntrypoint = entrypointMatch[1].trim()


### PR DESCRIPTION
## Summary
- SnapshotService.getEntrypointFromDockerfile crashes with TypeError when dockerfileContent is null/undefined
- Observed in production: \"Cannot read properties of undefined (reading match)\"
- Added null guard returning default entrypoint when dockerfileContent is missing

## Test plan
- [ ] Create snapshot with buildInfo but no dockerfileContent
- [ ] Verify default entrypoint [\"sleep\", \"infinity\"] is used