### PR TITLE
fix: increase health check timeouts to reduce false-positive failures

### DIFF
--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -32,7 +32,10 @@ export class HealthController {
   @HealthCheck()
   async check() {
     try {
-      const result = await this.health.check([() => this.db.pingCheck('database'), () => this.redis.isHealthy('redis')])
+      const result = await this.health.check([
+        () => this.db.pingCheck('database', { timeout: 5000 }),
+        () => this.redis.isHealthy('redis'),
+      ])
       return { status: result.status }
     } catch (error) {
       this.logger.error(error)

--- a/apps/api/src/health/redis.health.ts
+++ b/apps/api/src/health/redis.health.ts
@@ -16,7 +16,7 @@ export class RedisHealthIndicator {
     private readonly healthIndicatorService: HealthIndicatorService,
   ) {
     this.redis = redis.duplicate({
-      commandTimeout: 1000,
+      commandTimeout: 5000,
     })
   }
 


### PR DESCRIPTION
## Summary
- 49 \"Health Check has failed\" events in 7d where DB reports \"timeout of 1000ms exceeded\"
- Increased TypeORM pingCheck timeout from 1000ms to 5000ms
- Increased Redis commandTimeout from 1000ms to 5000ms

## Test plan
- [ ] Verify health check passes during normal load
- [ ] Verify health check correctly fails when DB/Redis is actually down