### PR TITLE
fix: add ECONNREFUSED and other network errors to runner adapter retry list

### DIFF
--- a/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
+++ b/apps/api/src/sandbox/runner-adapter/runnerAdapter.v0.ts
@@ -42,8 +42,7 @@ import { RunnerApiError } from '../errors/runner-api-error'
 
 const isDebugEnabled = process.env.DEBUG === 'true'
 
-// Network error codes that should trigger a retry
-const RETRYABLE_NETWORK_ERROR_CODES = ['ECONNRESET', 'ETIMEDOUT']
+const RETRYABLE_NETWORK_ERROR_CODES = ['ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED', 'EHOSTUNREACH', 'ENETUNREACH', 'EAI_AGAIN']
 
 @Injectable()
 export class RunnerAdapterV0 implements RunnerAdapter {


### PR DESCRIPTION
## Summary
- RunnerAdapterV0 only retried on ECONNRESET and ETIMEDOUT
- Production shows frequent ECONNREFUSED when runners restart
- Added ECONNREFUSED, EHOSTUNREACH, ENETUNREACH, EAI_AGAIN to retryable list

## Test plan
- [ ] Verify runner adapter retries on ECONNREFUSED
- [ ] Verify retry count and backoff still work correctly