### PR TITLE
fix: treat 403 as non-retryable in transient image cleanup

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -813,8 +813,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       try {
         await this.dockerRegistryService.removeImage(snapshot.imageName, transientRegistry.id)
       } catch (error) {
-        if (error.statusCode === 404) {
-          //  image not found, just return
+        if (error.statusCode === 404 || error.statusCode === 403 || error.response?.status === 403) {
           return DONT_SYNC_AGAIN
         }
         this.logger.error('Failed to remove transient image:', fromAxiosError(error))


### PR DESCRIPTION
## Summary
- SnapshotManager logs errors when transient registry image deletion returns 403
- 403 is a permissions issue that won't resolve on retry, treat same as 404

## Test plan
- [ ] Verify 403 from registry does not log error-level messages
- [ ] Verify 404 still works correctly