### PR TITLE
fix: expand RECOVERY_ERROR_SUBSTRINGS to cover transient network and container errors

### DIFF
--- a/apps/api/src/sandbox/constants/errors-for-recovery.ts
+++ b/apps/api/src/sandbox/constants/errors-for-recovery.ts
@@ -3,5 +3,15 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-// Substrings in an error message that should trigger an automatic restore
-export const RECOVERY_ERROR_SUBSTRINGS: string[] = ['Can not connect to the Docker daemon']
+export const RECOVERY_ERROR_SUBSTRINGS: string[] = [
+  'Can not connect to the Docker daemon',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'AggregateError',
+  'no such container',
+  'container is not running',
+  'network is unreachable',
+]


### PR DESCRIPTION
## Summary
- SandboxStartAction only recovered from Docker daemon errors
- Added ECONNREFUSED, ETIMEDOUT, ECONNRESET, AggregateError, container lifecycle errors
- Enables automatic sandbox migration when runner has transient issues

## Test plan
- [ ] Verify sandbox start triggers recovery on network errors
- [ ] Verify sandbox migrates to new runner on connection failure