### PR TITLE
fix: suppress context.Canceled errors in proxy last-activity cache operations

### DIFF
--- a/apps/proxy/pkg/proxy/get_sandbox_target.go
+++ b/apps/proxy/pkg/proxy/get_sandbox_target.go
@@ -308,7 +308,9 @@ func (p *Proxy) updateLastActivity(ctx context.Context, sandboxId string, should
 	// Prevent frequent updates by caching the last update
 	cached, err := p.sandboxLastActivityUpdateCache.Has(ctx, sandboxId)
 	if err != nil {
-		// If cache doesn't work, skip the update to avoid spamming the API
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return
+		}
 		log.Errorf("failed to check last activity update cache for sandbox %s: %v", sandboxId, err)
 		return
 	}
@@ -329,7 +331,9 @@ func (p *Proxy) updateLastActivity(ctx context.Context, sandboxId string, should
 		// Expire a bit before the poll interval to avoid skipping one interval
 		err = p.sandboxLastActivityUpdateCache.Set(ctx, sandboxId, true, pollInterval-5*time.Second)
 		if err != nil {
-			log.Errorf("failed to set last activity update cache for sandbox %s: %v", sandboxId, err)
+			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+				log.Errorf("failed to set last activity update cache for sandbox %s: %v", sandboxId, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Proxy logs noisy errors when client disconnects mid-request
- Added context.Canceled/DeadlineExceeded checks for Redis cache Has() and Set() calls
- Matches existing pattern used for the API call in the same function

## Test plan
- [ ] Verify client disconnect does not log cache errors
- [ ] Verify actual cache failures still log errors