### PR TITLE
fix: handle connection errors during sandbox cleanup on previous runner

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-start.action.ts
@@ -852,12 +852,19 @@ export class SandboxStartAction extends SandboxAction {
     const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
     try {
-      // First try to destroy the sandbox
       await runnerAdapter.destroySandbox(sandbox.id)
     } catch (error) {
-      if (error.response?.status !== 404 && error.statusCode !== 404) {
+      const isNotFound = error.response?.status === 404 || error.statusCode === 404
+      const isConnectionError = error.isConnectionError?.() ||
+        ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EHOSTUNREACH'].some((c) => error.message?.includes(c))
+
+      if (!isNotFound && !isConnectionError) {
         this.logger.error(`Failed to cleanup sandbox ${sandbox.id} on previous runner ${runner.id}:`, error)
         throw error
+      }
+
+      if (isConnectionError) {
+        this.logger.warn(`Previous runner ${runner.id} unreachable during cleanup of sandbox ${sandbox.id}, proceeding`)
       }
     }
 


### PR DESCRIPTION
## Summary
- SandboxStartAction.removeSandboxFromPreviousRunner throws on runner connection errors, blocking sandbox migration
- If previous runner is unreachable, cleanup is best-effort — proceed with new runner

## Test plan
- [ ] Verify sandbox starts on new runner even if previous runner is down
- [ ] Verify cleanup still works when previous runner is reachable