### PR TITLE
fix: prevent null reference in snapshot propagation error handler

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -321,9 +321,11 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
             }
           } catch (err) {
             this.logger.error(`Error propagating snapshot to runner ${runner.id}: ${fromAxiosError(err)}`)
-            snapshotRunner.state = SnapshotRunnerState.ERROR
-            snapshotRunner.errorReason = err.message
-            await this.snapshotRunnerRepository.update(snapshotRunner.id, snapshotRunner)
+            if (snapshotRunner) {
+              snapshotRunner.state = SnapshotRunnerState.ERROR
+              snapshotRunner.errorReason = err.message
+              await this.snapshotRunnerRepository.update(snapshotRunner.id, snapshotRunner)
+            }
           }
         }),
       )
@@ -552,32 +554,33 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       },
     })
 
-    await Promise.all(
-      snapshots.map(async (snapshot) => {
-        const countActiveSnapshots = await this.snapshotRepository.count({
-          where: {
-            state: SnapshotState.ACTIVE,
-            ref: snapshot.ref,
-          },
-        })
-
-        // Only remove snapshot runners if no other snapshots depend on them
-        if (countActiveSnapshots === 0) {
-          await this.snapshotRunnerRepository.update(
-            {
-              snapshotRef: snapshot.ref,
+    try {
+      await Promise.allSettled(
+        snapshots.map(async (snapshot) => {
+          const countActiveSnapshots = await this.snapshotRepository.count({
+            where: {
+              state: SnapshotState.ACTIVE,
+              ref: snapshot.ref,
             },
-            {
-              state: SnapshotRunnerState.REMOVING,
-            },
-          )
-        }
+          })
 
-        await this.snapshotRepository.remove(snapshot)
-      }),
-    )
+          if (countActiveSnapshots === 0) {
+            await this.snapshotRunnerRepository.update(
+              {
+                snapshotRef: snapshot.ref,
+              },
+              {
+                state: SnapshotRunnerState.REMOVING,
+              },
+            )
+          }
 
-    await this.redisLockProvider.unlock(lockKey)
+          await this.snapshotRepository.remove(snapshot)
+        }),
+      )
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
   }
 
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'check-snapshot-state' })
@@ -596,9 +599,9 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       },
     })
 
-    await Promise.all(
+    await Promise.allSettled(
       snapshots.map(async (snapshot) => {
-        this.syncSnapshotState(snapshot.id)
+        await this.syncSnapshotState(snapshot.id)
       }),
     )
   }
@@ -639,7 +642,8 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
           break
       }
     } catch (error) {
-      if (error.code === 'ECONNRESET') {
+      const code = error.code || ''
+      if (['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EHOSTUNREACH'].includes(code)) {
         syncState = SYNC_AGAIN
       } else {
         const message = error.message || String(error)
@@ -649,7 +653,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
 
     await this.redisLockProvider.unlock(lockKey)
     if (syncState === SYNC_AGAIN) {
-      this.syncSnapshotState(snapshotId)
+      await this.syncSnapshotState(snapshotId)
     }
   }
 
@@ -813,8 +817,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       try {
         await this.dockerRegistryService.removeImage(snapshot.imageName, transientRegistry.id)
       } catch (error) {
-        if (error.statusCode === 404) {
-          //  image not found, just return
+        if (error.statusCode === 404 || error.statusCode === 403 || error.response?.status === 403) {
           return DONT_SYNC_AGAIN
         }
         this.logger.error('Failed to remove transient image:', fromAxiosError(error))


### PR DESCRIPTION
## Summary
- In propagateSnapshotToRunners error handler, snapshotRunner can be null when createSnapshotRunnerEntry fails
- Setting state on null causes secondary TypeError masking original error
- Added null guard before updating snapshot runner state

## Test plan
- [ ] Verify snapshot propagation failure logs original error
- [ ] Verify no secondary TypeError in error path