### PR TITLE
fix: add catch block to usage service event handler

### DIFF
--- a/apps/api/src/usage/services/usage.service.ts
+++ b/apps/api/src/usage/services/usage.service.ts
@@ -66,6 +66,8 @@ export class UsageService implements TrackableJobExecutions, OnApplicationShutdo
           break
         }
       }
+    } catch (error) {
+      this.logger.error(`Failed to process usage for sandbox ${event.sandbox.id} (${event.oldState} → ${event.newState}):`, error)
     } finally {
       this.releaseLock(event.sandbox.id).catch((error) => {
         this.logger.error(`Error releasing lock for sandbox ${event.sandbox.id}`, error)


### PR DESCRIPTION
## Summary
- UsageService.handleSandboxStateUpdate has try/finally but no catch
- DB errors propagate as unhandled rejections
- Added catch block with error logging

## Test plan
- [ ] Verify usage tracking errors are logged, not unhandled
- [ ] Verify lock is always released on error