### PR TITLE
fix: handle missing internal registry gracefully in snapshot runner propagation

### DIFF
--- a/apps/api/src/sandbox/managers/snapshot.manager.ts
+++ b/apps/api/src/sandbox/managers/snapshot.manager.ts
@@ -321,9 +321,11 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
             }
           } catch (err) {
             this.logger.error(`Error propagating snapshot to runner ${runner.id}: ${fromAxiosError(err)}`)
-            snapshotRunner.state = SnapshotRunnerState.ERROR
-            snapshotRunner.errorReason = err.message
-            await this.snapshotRunnerRepository.update(snapshotRunner.id, snapshotRunner)
+            if (snapshotRunner) {
+              snapshotRunner.state = SnapshotRunnerState.ERROR
+              snapshotRunner.errorReason = err.message
+              await this.snapshotRunnerRepository.update(snapshotRunner.id, snapshotRunner)
+            }
           }
         }),
       )
@@ -383,9 +385,13 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
         runner.region,
       )
       if (!internalRegistry) {
-        throw new Error(
-          `No internal registry found for snapshot ${snapshotRunner.snapshotRef} in region ${runner.region}`,
+        this.logger.warn(
+          `No internal registry found for snapshot ${snapshotRunner.snapshotRef} in region ${runner.region}, marking as error`,
         )
+        snapshotRunner.state = SnapshotRunnerState.ERROR
+        snapshotRunner.errorReason = `No internal registry in region ${runner.region}`
+        await this.snapshotRunnerRepository.save(snapshotRunner)
+        return
       }
       await this.pullSnapshotRunner(runner, snapshotRunner.snapshotRef, internalRegistry)
       return
@@ -552,32 +558,33 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       },
     })
 
-    await Promise.all(
-      snapshots.map(async (snapshot) => {
-        const countActiveSnapshots = await this.snapshotRepository.count({
-          where: {
-            state: SnapshotState.ACTIVE,
-            ref: snapshot.ref,
-          },
-        })
-
-        // Only remove snapshot runners if no other snapshots depend on them
-        if (countActiveSnapshots === 0) {
-          await this.snapshotRunnerRepository.update(
-            {
-              snapshotRef: snapshot.ref,
+    try {
+      await Promise.allSettled(
+        snapshots.map(async (snapshot) => {
+          const countActiveSnapshots = await this.snapshotRepository.count({
+            where: {
+              state: SnapshotState.ACTIVE,
+              ref: snapshot.ref,
             },
-            {
-              state: SnapshotRunnerState.REMOVING,
-            },
-          )
-        }
+          })
 
-        await this.snapshotRepository.remove(snapshot)
-      }),
-    )
+          if (countActiveSnapshots === 0) {
+            await this.snapshotRunnerRepository.update(
+              {
+                snapshotRef: snapshot.ref,
+              },
+              {
+                state: SnapshotRunnerState.REMOVING,
+              },
+            )
+          }
 
-    await this.redisLockProvider.unlock(lockKey)
+          await this.snapshotRepository.remove(snapshot)
+        }),
+      )
+    } finally {
+      await this.redisLockProvider.unlock(lockKey)
+    }
   }
 
   @Cron(CronExpression.EVERY_10_SECONDS, { name: 'check-snapshot-state' })
@@ -596,9 +603,9 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       },
     })
 
-    await Promise.all(
+    await Promise.allSettled(
       snapshots.map(async (snapshot) => {
-        this.syncSnapshotState(snapshot.id)
+        await this.syncSnapshotState(snapshot.id)
       }),
     )
   }
@@ -639,7 +646,8 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
           break
       }
     } catch (error) {
-      if (error.code === 'ECONNRESET') {
+      const code = error.code || ''
+      if (['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EHOSTUNREACH'].includes(code)) {
         syncState = SYNC_AGAIN
       } else {
         const message = error.message || String(error)
@@ -649,7 +657,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
 
     await this.redisLockProvider.unlock(lockKey)
     if (syncState === SYNC_AGAIN) {
-      this.syncSnapshotState(snapshotId)
+      await this.syncSnapshotState(snapshotId)
     }
   }
 
@@ -813,8 +821,7 @@ export class SnapshotManager implements TrackableJobExecutions, OnApplicationShu
       try {
         await this.dockerRegistryService.removeImage(snapshot.imageName, transientRegistry.id)
       } catch (error) {
-        if (error.statusCode === 404) {
-          //  image not found, just return
+        if (error.statusCode === 404 || error.statusCode === 403 || error.response?.status === 403) {
           return DONT_SYNC_AGAIN
         }
         this.logger.error('Failed to remove transient image:', fromAxiosError(error))


### PR DESCRIPTION
## Summary
- \"No internal registry found for snapshot in region\" throws unhandled Error (4 occurrences in 7d)
- This is a configuration issue, not transient — retrying won't help
- Mark snapshot runner as ERROR with descriptive reason instead of throwing

## Test plan
- [ ] Verify missing registry logs warning and marks runner as error
- [ ] Verify other runners in different regions still propagate