### PR TITLE
fix(api): skip v0 runner health check when apiUrl is missing

### DIFF
--- a/apps/api/src/sandbox/services/runner.service.ts
+++ b/apps/api/src/sandbox/services/runner.service.ts
@@ -544,6 +544,11 @@ export class RunnerService {
           }
 
           // v0 runners: imperative health check via adapter
+          if (!runner.apiUrl) {
+            this.logger.warn(`Runner ${runner.id} has no API URL configured, skipping health check`)
+            return
+          }
+
           const shouldRetry = runner.state === RunnerState.READY
           const retryDelays = shouldRetry ? [500, 1000] : []
 


### PR DESCRIPTION
## Summary
- Skip v0 runners with no API URL configured in the `handleCheckRunners` cron, logging a warning instead of throwing

## Production evidence
```
[RunnerService] Error checking runner 5fd21452-...
  err: Runner API URL is required
```
~10 occurrences/6h. Occurs when a runner exists in the DB but has no `apiUrl` set.

## Test plan
- [ ] Verify runners with valid `apiUrl` still get health-checked normally
- [ ] Verify runners with null/empty `apiUrl` are skipped with a warning log
- [ ] Confirm "Runner API URL is required" errors stop appearing