### PR TITLE
fix(api): handle connection errors in destroy and stop actions

### DIFF
--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-destroy.action.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Injectable } from '@nestjs/common'
+import { Injectable, Logger } from '@nestjs/common'
 import { Sandbox } from '../../entities/sandbox.entity'
 import { SandboxState } from '../../enums/sandbox-state.enum'
 import { DONT_SYNC_AGAIN, SandboxAction, SyncState, SYNC_AGAIN } from './sandbox.action'
@@ -14,8 +14,12 @@ import { SandboxRepository } from '../../repositories/sandbox.repository'
 import { LockCode, RedisLockProvider } from '../../common/redis-lock.provider'
 import { WithSpan } from '../../../common/decorators/otel.decorator'
 
+const CONNECTION_ERROR_CODES = ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EHOSTUNREACH', 'ENETUNREACH', 'EAI_AGAIN']
+
 @Injectable()
 export class SandboxDestroyAction extends SandboxAction {
+  private readonly logger = new Logger(SandboxDestroyAction.name)
+
   constructor(
     protected runnerService: RunnerService,
     protected runnerAdapterFactory: RunnerAdapterFactory,
@@ -58,8 +62,18 @@ export class SandboxDestroyAction extends SandboxAction {
 
       return SYNC_AGAIN
     } catch (error) {
-      //  if the sandbox is not found on runner, it is already destroyed
       if (error.response?.status === 404 || error.statusCode === 404) {
+        await this.updateSandboxState(sandbox, SandboxState.DESTROYED, lockCode)
+        return DONT_SYNC_AGAIN
+      }
+
+      const isConnectionError = CONNECTION_ERROR_CODES.some(
+        (code) => error.code === code || error.message?.includes(code),
+      )
+      if (isConnectionError && sandbox.state === SandboxState.DESTROYING) {
+        this.logger.warn(
+          `Runner unreachable during destroy of sandbox ${sandbox.id} (${error.code || error.message}), marking as destroyed`,
+        )
         await this.updateSandboxState(sandbox, SandboxState.DESTROYED, lockCode)
         return DONT_SYNC_AGAIN
       }

--- a/apps/api/src/sandbox/managers/sandbox-actions/sandbox-stop.action.ts
+++ b/apps/api/src/sandbox/managers/sandbox-actions/sandbox-stop.action.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0
  */
 
-import { Injectable } from '@nestjs/common'
+import { Injectable, Logger } from '@nestjs/common'
 import { Sandbox } from '../../entities/sandbox.entity'
 import { SandboxState } from '../../enums/sandbox-state.enum'
 import { DONT_SYNC_AGAIN, SandboxAction, SyncState, SYNC_AGAIN } from './sandbox.action'
@@ -15,8 +15,12 @@ import { SandboxRepository } from '../../repositories/sandbox.repository'
 import { LockCode, RedisLockProvider } from '../../common/redis-lock.provider'
 import { WithSpan } from '../../../common/decorators/otel.decorator'
 
+const CONNECTION_ERROR_CODES = ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EHOSTUNREACH', 'ENETUNREACH', 'EAI_AGAIN']
+
 @Injectable()
 export class SandboxStopAction extends SandboxAction {
+  private readonly logger = new Logger(SandboxStopAction.name)
+
   constructor(
     protected runnerService: RunnerService,
     protected runnerAdapterFactory: RunnerAdapterFactory,
@@ -35,43 +39,71 @@ export class SandboxStopAction extends SandboxAction {
 
     const runnerAdapter = await this.runnerAdapterFactory.create(runner)
 
-    if (sandbox.state === SandboxState.STARTED) {
-      // stop sandbox
-      await runnerAdapter.stopSandbox(sandbox.id)
-      await this.updateSandboxState(sandbox, SandboxState.STOPPING, lockCode)
+    try {
+      if (sandbox.state === SandboxState.STARTED) {
+        await runnerAdapter.stopSandbox(sandbox.id)
+        await this.updateSandboxState(sandbox, SandboxState.STOPPING, lockCode)
 
-      //  sync states again immediately for sandbox
+        return SYNC_AGAIN
+      }
+
+      if (sandbox.state !== SandboxState.STOPPING && sandbox.state !== SandboxState.ERROR) {
+        return DONT_SYNC_AGAIN
+      }
+
+      const sandboxInfo = await runnerAdapter.sandboxInfo(sandbox.id)
+
+      if (sandboxInfo.state === SandboxState.STOPPED) {
+        await this.updateSandboxState(
+          sandbox,
+          SandboxState.STOPPED,
+          lockCode,
+          undefined,
+          undefined,
+          undefined,
+          BackupState.NONE,
+        )
+        return DONT_SYNC_AGAIN
+      } else if (sandboxInfo.state === SandboxState.ERROR) {
+        await this.updateSandboxState(
+          sandbox,
+          SandboxState.ERROR,
+          lockCode,
+          undefined,
+          'Sandbox is in error state on runner',
+        )
+        return DONT_SYNC_AGAIN
+      }
+
       return SYNC_AGAIN
-    }
+    } catch (error) {
+      if (error.response?.status === 404 || error.statusCode === 404) {
+        this.logger.warn(
+          `Runner returned 404 during stop of sandbox ${sandbox.id}, marking as stopped`,
+        )
+        await this.updateSandboxState(
+          sandbox,
+          SandboxState.STOPPED,
+          lockCode,
+          undefined,
+          undefined,
+          undefined,
+          BackupState.NONE,
+        )
+        return DONT_SYNC_AGAIN
+      }
 
-    if (sandbox.state !== SandboxState.STOPPING && sandbox.state !== SandboxState.ERROR) {
-      return DONT_SYNC_AGAIN
-    }
-
-    const sandboxInfo = await runnerAdapter.sandboxInfo(sandbox.id)
-
-    if (sandboxInfo.state === SandboxState.STOPPED) {
-      await this.updateSandboxState(
-        sandbox,
-        SandboxState.STOPPED,
-        lockCode,
-        undefined,
-        undefined,
-        undefined,
-        BackupState.NONE,
+      const isConnectionError = CONNECTION_ERROR_CODES.some(
+        (code) => error.code === code || error.message?.includes(code),
       )
-      return DONT_SYNC_AGAIN
-    } else if (sandboxInfo.state === SandboxState.ERROR) {
-      await this.updateSandboxState(
-        sandbox,
-        SandboxState.ERROR,
-        lockCode,
-        undefined,
-        'Sandbox is in error state on runner',
-      )
-      return DONT_SYNC_AGAIN
-    }
+      if (isConnectionError && sandbox.state === SandboxState.STOPPING) {
+        this.logger.warn(
+          `Runner unreachable during stop of sandbox ${sandbox.id} (${error.code || error.message}), will retry on next sync`,
+        )
+        return DONT_SYNC_AGAIN
+      }
 
-    return SYNC_AGAIN
+      throw error
+    }
   }
 }


### PR DESCRIPTION
## Summary
- **Destroy action**: when already DESTROYING and runner is unreachable (ETIMEDOUT, ECONNREFUSED, etc.), mark as destroyed
- **Stop action**: wrap in try/catch; handle 404 (mark stopped) and connection errors gracefully

## Production evidence
```
[RunnerAdapterV0] Retrying request due to ETIMEDOUT (attempt 3): GET /sandboxes/...
[SandboxManager] Error processing desired state for sandbox ...
```
Sandboxes stuck in `destroying`/`stopping` when runners have network issues.

## Test plan
- [ ] Verify destroy marks as destroyed when runner unreachable and already in destroying state
- [ ] Verify stop handles 404 by marking as stopped
- [ ] Verify connection errors during stop don't cause unhandled exceptions
- [ ] Verify non-connection errors still throw correctly